### PR TITLE
Add "End timeline" command

### DIFF
--- a/command_list.gd
+++ b/command_list.gd
@@ -14,6 +14,7 @@ var scripts:Array[Script] = [
 	load("res://addons/blockflow/commands/command_return.gd") as Script,
 	load("res://addons/blockflow/commands/command_set.gd") as Script,
 	load("res://addons/blockflow/commands/command_wait.gd") as Script,
+	load("res://addons/blockflow/commands/command_end.gd") as Script,
 	]
 
 var command_button_list_pressed:Callable

--- a/command_manager.gd
+++ b/command_manager.gd
@@ -20,9 +20,8 @@ signal timeline_finished(timeline_resource)
 
 ## Return values used in [return_command]
 enum ReturnValue {
-	BEFORE=-1, ## Returns a command behind GoTo
-	AFTER=1, ## Returns a command after GoTo
-	NO_RETURN, ## Ends inmediatly the execution process and end the timeline.
+	REPEAT=0, ## Returns on the GoTo repeating it
+	NEXT=1, ## Returns a command after GoTo
 	}
 
 const _GoToCommand = preload("res://addons/blockflow/commands/command_goto.gd")
@@ -129,23 +128,21 @@ func go_to_previous_command() -> void:
 ## Returns to a previous [code]GoTo[/code] command call.
 ## See [ReturnValue] to know possible values for [code]return_value[/code]
 ## argument.
-func return_command(return_value:ReturnValue):
+func return_command(return_value:ReturnValue, return_timeline:bool = false):
 	assert(!_jump_history.is_empty())
-	if return_value == ReturnValue.NO_RETURN:
-		_notify_timeline_end()
-		_disconnect_command_signals(current_command)
-		return
-	
-	var jump_data:Array = _jump_history.pop_back()
-	var history_from:Array = jump_data[ _JumpHistoryData.FROM ]
-	
-	var next_command_idx:int = history_from\
-	[ _HistoryData.COMMAND_INDEX ] + return_value
-	
-	var next_timeline:Timeline =  history_from[ _HistoryData.TIMELINE ]
-	
+
+	var next_command_idx:int
+	var next_timeline:Timeline = current_timeline
+	while next_timeline == current_timeline:
+		var jump_data:Array = _jump_history.pop_back()
+		var history_from:Array = jump_data[ _JumpHistoryData.FROM ]
+		next_command_idx = history_from [ _HistoryData.COMMAND_INDEX ] + return_value
+		next_timeline = history_from[ _HistoryData.TIMELINE ]
+		if not return_timeline:
+			break
+
 	go_to_command(next_command_idx, next_timeline)
-	
+
 
 # Set required data for a command. Used before _execute_command
 func _prepare_command(command:Command) -> void:

--- a/commands/command_end.gd
+++ b/commands/command_end.gd
@@ -1,0 +1,21 @@
+@tool
+extends Command
+
+
+func _execution_steps() -> void:
+	command_started.emit()
+	command_finished.emit()
+	command_manager._notify_timeline_end()
+	command_manager._disconnect_command_signals(command_manager.current_command)
+
+
+func _get_name() -> String:
+	return "End Timeline"
+
+
+func _get_icon() -> Texture:
+	return load("res://addons/blockflow/icons/stop.svg")
+
+func _init() -> void:
+	super()
+	continue_at_end = false

--- a/commands/command_return.gd
+++ b/commands/command_return.gd
@@ -28,7 +28,7 @@ func _get_name() -> StringName:
 
 func _get_hint() -> String:
 	return ("to last timeline" if to_last_timeline else "to last jump") +\
-		   (" (repeat)" if behavior == 0 else "")
+		(" (repeat)" if behavior == 0 else "")
 
 
 func _get_icon() -> Texture:

--- a/commands/command_return.gd
+++ b/commands/command_return.gd
@@ -1,18 +1,40 @@
 @tool
 extends Command
 
-enum ReturnValue {BEFORE=-1,NO_RETURN, AFTER}
+@export_enum("Repeat:0", "Next:1") var behavior: int = 1:
+	set(value):
+		behavior = value
+		emit_changed()
+	get:
+		return behavior
 
-var returns_to:int = ReturnValue.AFTER
+
+@export var to_last_timeline:bool = false:
+	set(value):
+		to_last_timeline = value
+		emit_changed()
+	get:
+		return to_last_timeline
+
 
 func _execution_steps() -> void:
 	command_started.emit()
-	command_manager.return_command(returns_to)
+	command_manager.return_command(behavior, to_last_timeline)
 
 
 func _get_name() -> StringName:
 	return "Return"
 
 
+func _get_hint() -> String:
+	return ("to last timeline" if to_last_timeline else "to last jump") +\
+		   (" (repeat)" if behavior == 0 else "")
+
+
 func _get_icon() -> Texture:
 	return load("res://addons/blockflow/icons/return.svg")
+
+
+func _init() -> void:
+	super()
+	continue_at_end = false


### PR DESCRIPTION
Splits the "no return" unimplemented behavior from the return command
Implement "repeat" and "next" behaviors for the return command, expose these settings to the user
Add a hint string to the return command
Add an option for the Return command to return to last timeline rather than last goto (though it'll still resume from the last timeline's jump)