### PR TITLE
Add CommandInspector

### DIFF
--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -3,17 +3,21 @@ extends EditorPlugin
 
 const TimelineEditor = preload("res://addons/blockflow/editor/editor.gd")
 const TimelineConverter = preload("res://addons/blockflow/timeline_converter.gd")
+const CommandInspector = preload("res://addons/blockflow/editor/inspector/command_inspector.gd")
 
 var timeline_editor:TimelineEditor
 var last_edited_timeline:CommandCollection
 var last_handled_object:Object
 var timeline_converter:TimelineConverter
+var command_inspector:CommandInspector
 
 func _enter_tree():
 	get_editor_interface().get_editor_main_screen().add_child(timeline_editor)
+	get_editor_interface().get_base_control().add_child(command_inspector.node_selector)
 	_make_visible(false)
 	
 	add_resource_conversion_plugin(timeline_converter)
+	add_inspector_plugin(command_inspector)
 
 
 func _handles(object: Object) -> bool:
@@ -57,6 +61,7 @@ func _exit_tree():
 	
 	remove_resource_conversion_plugin(timeline_converter)
 	timeline_converter = null
+	command_inspector = null
 
 
 func _init() -> void:
@@ -66,3 +71,8 @@ func _init() -> void:
 	timeline_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	
 	timeline_converter = TimelineConverter.new()
+	command_inspector = CommandInspector.new()
+	command_inspector.editor_plugin = self
+	command_inspector.node_selector = CommandInspector.NodeSelector.new()
+	command_inspector.node_selector.editor_plugin = self
+	tree_exited.connect(command_inspector.node_selector.queue_free)

--- a/editor/inspector/command_inspector.gd
+++ b/editor/inspector/command_inspector.gd
@@ -1,0 +1,114 @@
+@tool
+extends "res://addons/blockflow/editor/inspector/inspector_tools.gd"
+
+class TargetProperty extends EditorProperty:
+	var editor_plugin:EditorPlugin
+	var node_selector:NodeSelector
+	var selector:Button
+	var revert:Button
+	
+	func _update_property() -> void:
+		var property:String = get_edited_property()
+		var object:Object = get_edited_object()
+		var current_value:NodePath = object[property]
+		var current_scene:Node = editor_plugin.get_editor_interface().get_edited_scene_root()
+		
+		var text:String = current_value
+		var icon:Texture = null
+		revert.icon = get_theme_icon("Reload", "EditorIcons")
+		revert.hide()
+		
+		if text.is_empty():
+			text = "[None]"
+		else:
+			revert.show()
+			if is_instance_valid(current_scene):
+				var node:Node = current_scene.get_node_or_null(current_value)
+				if is_instance_valid(node):
+					icon = get_theme_icon(node.get_class(), "EditorIcons")
+				if text == ".":
+					text = "[Scene Root]"
+		
+		selector.tooltip_text = "NodePath(\"%s\")"%current_value
+		selector.text = text
+		selector.icon = icon
+		
+	
+	func _selector_pressed() -> void:
+		node_selector.popup_centered_ratio(0.25)
+		node_selector.confirmed.connect(_selector_confirmed, CONNECT_ONE_SHOT)
+	
+	func _selector_confirmed() -> void:
+		if not node_selector.selected_item:
+			return
+		var path:NodePath = node_selector.selected_item.get_metadata(0)
+		emit_changed(get_edited_property(), path)
+	
+	func _revert_pressed() -> void:
+		emit_changed(get_edited_property(), NodePath())
+	
+	func _init() -> void:
+		var hb := HBoxContainer.new()
+		hb.add_theme_constant_override("separation", 0)
+		add_child(hb)
+		
+		revert = Button.new()
+		revert.flat = true
+		revert.pressed.connect(_revert_pressed)
+		hb.add_child(revert)
+		
+		selector = Button.new()
+		selector.clip_text = true
+		selector.text_overrun_behavior = TextServer.OVERRUN_TRIM_WORD_ELLIPSIS
+		selector.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		selector.pressed.connect(_selector_pressed)
+		add_focusable(selector)
+		hb.add_child(selector)
+
+var node_selector:NodeSelector
+var _should_ignore:bool = false
+
+func _can_handle(object: Object) -> bool:
+	return object is Command
+
+func _parse_begin(object: Object) -> void:
+	_should_ignore = false
+
+
+func _parse_category(object: Object, category: String) -> void:
+	if category == "Resource":
+		_should_ignore = true
+	if _should_ignore:
+		var dummy = PrevNodeVanisher.new()
+		add_custom_control(dummy)
+
+
+func _parse_group(object: Object, group: String) -> void:
+	if _should_ignore:
+		var dummy = GroupVanisher.new()
+		add_custom_control(dummy)
+
+
+func _parse_property(
+	object: Object,
+	type: Variant.Type,
+	name: String,
+	hint_type: PropertyHint,
+	hint_string: String,
+	usage_flags: PropertyUsageFlags,
+	wide: bool ) -> bool:
+	
+	if name == "target":
+		var target_property = TargetProperty.new()
+		target_property.editor_plugin = editor_plugin
+		target_property.node_selector = node_selector
+		add_property_editor(name, target_property)
+		return true
+	
+	return _should_ignore
+
+func _parse_end(object: Object) -> void:
+	if _should_ignore:
+		var dummy = PrevNodeVanisher.new()
+		add_custom_control(dummy)
+	_should_ignore = false

--- a/editor/inspector/inspector_tools.gd
+++ b/editor/inspector/inspector_tools.gd
@@ -1,0 +1,66 @@
+@tool
+extends EditorInspectorPlugin
+
+var editor_plugin:EditorPlugin
+
+class NodeSelector extends ConfirmationDialog:
+	var editor_plugin:EditorPlugin
+	var fake_tree:Tree
+	var selected_item:TreeItem
+	
+	func _recursive_create(ref_item:TreeItem, ref_node:Node, root_node:Node) -> void:
+		ref_item.set_text(0, ref_node.name)
+		ref_item.set_icon(0, get_theme_icon(ref_node.get_class(), "EditorIcons"))
+		ref_item.set_metadata(0, root_node.get_path_to(ref_node))
+		
+		for child in ref_node.get_children():
+			var item:TreeItem = ref_item.create_child()
+			_recursive_create(item, child, root_node)
+	
+	func _notification(what: int) -> void:
+		if what == NOTIFICATION_VISIBILITY_CHANGED:
+			if not visible:
+				return
+			
+			fake_tree.clear()
+			fake_tree.deselect_all()
+			get_ok_button().disabled = true
+			var scene_root:Node =\
+			editor_plugin.get_editor_interface().get_edited_scene_root()
+			if not is_instance_valid(scene_root):
+				return
+			
+			var root:TreeItem = fake_tree.create_item()
+			root.set_text(0, scene_root.name)
+			root.set_icon(0, get_theme_icon(scene_root.get_class(), "EditorIcons"))
+			_recursive_create(root, scene_root, scene_root)
+	
+	func _fake_tree_item_selected() -> void:
+		selected_item = fake_tree.get_selected()
+		get_ok_button().disabled = selected_item == null
+	
+	func _fake_tree_item_activated() -> void:
+		selected_item = fake_tree.get_selected()
+		confirmed.emit()
+		hide()
+	
+	func _init() -> void:
+		name = "NodeSelector"
+		title = "Node Selector"
+		
+		fake_tree = Tree.new()
+		fake_tree.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		fake_tree.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		fake_tree.item_selected.connect(_fake_tree_item_selected)
+		fake_tree.item_activated.connect(_fake_tree_item_activated)
+		add_child(fake_tree)
+
+class PrevNodeVanisher extends Control:
+	func _ready() -> void:
+		get_parent().get_child(get_index()-1).set("visible", false)
+		queue_free()
+
+class GroupVanisher extends Control:
+	func _ready() -> void:
+		get_parent().get_parent().set("visible", false)
+		queue_free()


### PR DESCRIPTION
Add an EditorPluginInspector to inspect Commands
Set target property has its own NodeSelector.

This will make easier to extend to create custom inspector for all commands.
![image](https://github.com/AnidemDex/Blockflow/assets/7025991/e928b96d-4078-4cc3-9ed2-f470519d2d47)
