### PR TITLE
Creates a way to filter which types of commands a command can hold

### DIFF
--- a/commands/branch_false.gd
+++ b/commands/branch_false.gd
@@ -8,3 +8,5 @@ func _get_icon() -> Texture:
 
 func _init() -> void:
 	branch_name = "is False"
+
+func _can_be_moved() -> bool: return false

--- a/commands/branch_true.gd
+++ b/commands/branch_true.gd
@@ -6,3 +6,5 @@ func _get_icon() -> Texture:
 
 func _init() -> void:
 	branch_name = "is True"
+
+func _can_be_moved() -> bool: return false

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -234,6 +234,9 @@ func is_branch() -> bool:
 func is_subcommand() -> bool:
 	return get_command_owner() != null
 
+func can_hold(command) -> bool:
+	return can_hold_commands
+
 ## Defines the execution behaviour of this command.
 ## This function is the default value of [member execution_steps]
 ## and you should override it if you are defining the command in a

--- a/commands/command_condition.gd
+++ b/commands/command_condition.gd
@@ -24,6 +24,11 @@ func _get_name() -> StringName: return "Condition"
 func _get_icon() -> Texture:
 	return load("res://addons/blockflow/icons/branch.svg")
 
+func _can_hold_commands() -> bool: return true
+
+func can_hold(command) -> bool:
+	return command.is_branch()
+
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_UPDATE_STRUCTURE:
 		if generate_default_branches:

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -436,19 +436,20 @@ func _collection_displayer_can_drop_data(at_position: Vector2, data) -> bool:
 		ref_block_command = ref_block.get(&"command")
 	
 		if ref_block_command.can_hold_commands:
-			collection_displayer.drop_mode_flags = Tree.DROP_MODE_ON_ITEM
-			return true
+			if ref_block_command.can_hold(moved_command):
+				collection_displayer.drop_mode_flags = Tree.DROP_MODE_ON_ITEM
+				return true
+			else:
+				collection_displayer.drop_mode_flags = Tree.DROP_MODE_DISABLED
+				return false
 	
 	if ref_block_command == moved_command:
 		collection_displayer.drop_mode_flags = Tree.DROP_MODE_DISABLED
 		return false
 	
-	var command:Blockflow.CommandClass = (data as Dictionary).get("resource") as Blockflow.CommandClass
-	if command:
-		collection_displayer.drop_mode_flags = Tree.DROP_MODE_INBETWEEN
-		return true
 	
-	return false
+	collection_displayer.drop_mode_flags = Tree.DROP_MODE_INBETWEEN
+	return true
 
 
 func _collection_displayer_drop_data(at_position: Vector2, data) -> void:


### PR DESCRIPTION
Adds `Command.can_hold` method to verify if a command can hold certain type of command. This is used by editor only, specifically on drop data part, and never is enforced in any `Collection` method.

Fix #73 