### PR TITLE
Improve target inspector property

### DIFF
--- a/editor/inspector/command_inspector.gd
+++ b/editor/inspector/command_inspector.gd
@@ -30,7 +30,8 @@ class TargetProperty extends EditorProperty:
 				text = "[Scene Root]"
 		
 		selector.tooltip_text = "NodePath(\"%s\")"%current_value
-		selector.text = text
+		selector.text = text.get_file()
+		selector.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 		selector.icon = icon
 		
 	
@@ -39,10 +40,9 @@ class TargetProperty extends EditorProperty:
 		node_selector.confirmed.connect(_selector_confirmed, CONNECT_ONE_SHOT)
 	
 	func _selector_confirmed() -> void:
-		if not node_selector.selected_item:
+		if not node_selector.node_path:
 			return
-		var path:NodePath = node_selector.selected_item.get_metadata(0)
-		emit_changed(get_edited_property(), path)
+		emit_changed(get_edited_property(), node_selector.node_path)
 	
 	func _revert_pressed() -> void:
 		emit_changed(get_edited_property(), NodePath())


### PR DESCRIPTION
* Fix the target button text overrun behavior
* Make target button text only show the node name
* Make the inspector tool provide the NodePath and not the item
* Add a line edit input bar to give a custom NodePath (which is useful for targeting NodePaths during runtime)
funny video:

https://github.com/AnidemDex/Blockflow/assets/3470436/210be826-6124-41f9-a8c1-1139c9a748da

