### PR TITLE
add "background color" enum for commands

### DIFF
--- a/commands/command.gd
+++ b/commands/command.gd
@@ -36,6 +36,14 @@ const Branch = preload("res://addons/blockflow/commands/branch.gd")
 		emit_changed()
 	get: return continue_at_end
 
+## What color to paint this command with.
+## Purely visual!
+@export_enum("Blank", "Red", "Yellow", "Green", "Aqua", "Blue", "Purple", "Pink") var background_color:int:
+	set(value):
+		background_color = value
+		emit_changed()
+	get: return background_color
+
 ## Target [NodePath] this command points to.
 ## This value is used in runtime by its [member command_manager] 
 ##  to determine the [member target_node] and is always 

--- a/editor/command_block/block.gd
+++ b/editor/command_block/block.gd
@@ -26,6 +26,17 @@ var command_name:String = FALLBACK_NAME
 var command_icon:Texture = FALLBACK_ICON
 var command_hint:String = ""
 var command_hint_icon:Texture = null
+var command_background_color:Color = Color()
+var background_colors:PackedColorArray = [
+	Color(), # Blank
+	Color("#ff4545"), # Red
+	Color("#ffe345"), # Yellow
+	Color("#80ff45"), # Green
+	Color("#45ffa2"), # Aqua
+	Color("#45d7ff"), # Blue
+	Color("#8045ff"), # Purple
+	Color("#ff4596"), # Pink
+]
 
 func update() -> void:
 	command_name = command.command_name
@@ -34,7 +45,10 @@ func update() -> void:
 		command_icon = FALLBACK_ICON
 	command_hint = command.command_hint
 	command_hint_icon = command.command_hint_icon
-	
+	command_background_color = background_colors[command.background_color]
+	if command_background_color:
+		command_background_color.a = 0.25
+
 	var hint_tooltip:String = "Bookmark:\n"+command.bookmark
 	var bookmark_icon:Texture = BOOKMARK_ICON
 	
@@ -44,6 +58,10 @@ func update() -> void:
 	
 	for i in get_tree().columns:
 		set_icon_max_width(i, Blockflow.BLOCK_ICON_MIN_SIZE)
+		if not command_background_color:
+			clear_custom_bg_color(i)
+		else:
+			set_custom_bg_color(i, command_background_color, i != ColumnPosition.NAME_COLUMN)
 	
 	set_text(ColumnPosition.NAME_COLUMN, command_name)
 	set_icon(ColumnPosition.NAME_COLUMN, command_icon)


### PR DESCRIPTION
It colors the background of the command, uses editor conventional colors
![image](https://github.com/AnidemDex/Blockflow/assets/3470436/07164012-8aa6-4b41-93d1-f1737cd0bafb)

The way the outline is bugged is due to the Tree node we're using, engine bug :/