### PR TITLE
Fix moving last item in branch to slot 0 failing

### DIFF
--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -485,12 +485,10 @@ func _collection_displayer_drop_data(at_position: Vector2, data) -> void:
 			move_command(command, -1, null, _current_collection)
 
 		_DropSection.ABOVE_ITEM:
-			
-			var prev_c:Blockflow.CommandClass = ref_item_collection.get_command(ref_item.command.index - 1)
+			var prev_c:Blockflow.CommandClass = ref_item_collection.get_command(max(0, ref_item.command.index - 1))
 			if prev_c == command:
 				# No need to move
 				return
-			
 			var new_index:int = ref_item.command.index - int(ref_item.command.index >= command.index)
 			if ref_item_collection != command.get_command_owner():
 				new_index = ref_item.command.index

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -504,6 +504,11 @@ func _collection_displayer_drop_data(at_position: Vector2, data) -> void:
 			
 			
 		_DropSection.BELOW_ITEM:
+			var ref_item_command = ref_item.get(&"command")
+			if ref_item_command.can_hold(command):
+				move_command(command, 0, null, ref_item.command)
+				return
+			
 			var next_c:Blockflow.CommandClass
 			
 			var new_index:int = ref_item.command.index + int(ref_item.command.index < command.index)

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -504,7 +504,7 @@ func _collection_displayer_drop_data(at_position: Vector2, data) -> void:
 			
 			
 		_DropSection.BELOW_ITEM:
-			var ref_item_command = ref_item.get(&"command")
+			var ref_item_command = ref_item.command
 			if ref_item_command.can_hold(command):
 				move_command(command, 0, null, ref_item.command)
 				return


### PR DESCRIPTION
Before, if you dragged the last command in a branch into the first command, the action would fail. This is because the index gets rolled over when it's negative to the end of the collection

I also made it so when you drop 'below' the branch, it will assume you're trying to drop into the branch but at 0th index.


https://github.com/AnidemDex/Blockflow/assets/3470436/36a620dd-7601-45a1-a8f9-93e07b2064ff



Also fixed a stack overflow + possible crash if you move a branch into itself or its children

https://github.com/AnidemDex/Blockflow/assets/3470436/0c4bf131-421c-4743-b710-5a69256a504b

