### PR TITLE
Deprecate unused classes

### DIFF
--- a/blockflow.gd
+++ b/blockflow.gd
@@ -32,6 +32,7 @@ const CollectionClass = preload("res://addons/blockflow/collection.gd")
 const CommandCollectionClass = preload("res://addons/blockflow/command_collection.gd")
 const CommandClass = preload("res://addons/blockflow/commands/command.gd")
 const CommandProcessorClass = preload("res://addons/blockflow/command_processor.gd")
+## @deprecated
 const TimelineClass = preload("res://addons/blockflow/timeline.gd")
 
 enum Toast {

--- a/command_manager.gd
+++ b/command_manager.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name CommandManager
 ##
 ## Manages the execution of timelines.
 ##
@@ -32,7 +31,7 @@ enum _HistoryData {TIMELINE, COMMAND_INDEX}
 enum _JumpHistoryData {HISTORY_INDEX, FROM, TO}
 
 ## Current timeline.
-@export var current_timeline:Timeline = null
+@export var current_timeline:Resource = null
 
 ## This is the node were commands will be applied to.
 ## This node is used if the command doesn't define an [member Command.target]
@@ -72,7 +71,7 @@ func _ready() -> void:
 ## [code]timeline[/code] was passed.
 ## You can optionally pass [code]from_command_index[/code] to define from
 ## where the timeline should start.
-func start_timeline(timeline:Timeline = null, from_command_index:int = 0) -> void:
+func start_timeline(timeline = null, from_command_index:int = 0) -> void:
 	current_command = null
 	current_command_idx = from_command_index
 	if timeline:
@@ -82,7 +81,7 @@ func start_timeline(timeline:Timeline = null, from_command_index:int = 0) -> voi
 
 ## Advances to a specific command in the [member]current_timeline[/member].
 ## If [code]timeline[/code] is a valid timeline, replaces the current timeline.
-func go_to_command(command_idx:int, timeline:Timeline=null) -> void:
+func go_to_command(command_idx:int, timeline=null) -> void:
 	# Check if there's a new timeline
 	if not(timeline == null or timeline == current_timeline):
 		current_timeline = timeline
@@ -132,7 +131,7 @@ func return_command(return_value:ReturnValue, return_timeline:bool = false):
 	assert(!_jump_history.is_empty())
 
 	var next_command_idx:int
-	var next_timeline:Timeline = current_timeline
+	var next_timeline = current_timeline
 	while next_timeline == current_timeline:
 		var jump_data:Array = _jump_history.pop_back()
 		var history_from:Array = jump_data[ _JumpHistoryData.FROM ]

--- a/commands/command_goto.gd
+++ b/commands/command_goto.gd
@@ -168,14 +168,14 @@ func _get_property_list():
 			"type": TYPE_STRING,
 			"usage": PROPERTY_USAGE_DEFAULT if use_bookmark else 0,
 		},
-		{
-			"name": "timeline", # @deprecated
-			"type": TYPE_OBJECT,
-			"class_name": "Timeline",
-			"usage": PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_READ_ONLY,
-			"hint": PROPERTY_HINT_RESOURCE_TYPE,
-			"hint_string": "Timeline"
-		},
+#		{
+#			"name": "timeline", # @deprecated
+#			"type": TYPE_OBJECT,
+#			"class_name": "Timeline",
+#			"usage": PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_READ_ONLY,
+#			"hint": PROPERTY_HINT_RESOURCE_TYPE,
+#			"hint_string": "Timeline"
+#		},
 		{
 			"name": "target_collection",
 			"type": TYPE_OBJECT,

--- a/debugger/timeline_debugger.gd
+++ b/debugger/timeline_debugger.gd
@@ -1,11 +1,13 @@
 extends Node
 
 const TimelineDisplayer = preload("res://addons/blockflow/editor/displayer.gd")
+## @deprecated
 const CommandManager = preload("res://addons/blockflow/command_manager.gd")
 
 ## Command manager node
 var cm_manager:CommandManager
-var timeline:Timeline
+## @deprecated
+var timeline
 
 # Suggestion:
 # in the future, you can export nodepaths in case the structure starts changing.

--- a/editor/playground/all_commands.gd
+++ b/editor/playground/all_commands.gd
@@ -1,6 +1,8 @@
 extends Node
 
-var timeline:Timeline = load("res://addons/blockflow/editor/playground/timeline_with_all_commands.tres")
+## @deprecated
+var timeline = load("res://addons/blockflow/editor/playground/timeline_with_all_commands.tres")
+
 @onready var cm = $CommandManager
 @onready var tm_debugger = $Window/TimelineDebugger
 


### PR DESCRIPTION
Remove references to Timeline and CommandManager in scripts, making them easy and safe to remove in future versions.