### PR TITLE
Fix return command by using main_collection

### DIFF
--- a/command_processor.gd
+++ b/command_processor.gd
@@ -284,10 +284,10 @@ func _execute_command(command:Blockflow.CommandClass) -> void:
 
 
 func _add_to_history() -> void:
-	assert(bool(current_collection != null))
+	assert(bool(main_collection != null))
 	var history_value = []
 	history_value.resize(_HistoryData.size())
-	history_value[_HistoryData.COLLECTION] = current_collection
+	history_value[_HistoryData.COLLECTION] = main_collection
 	history_value[_HistoryData.COMMAND_POSITION] = current_command_position
 	_history.append(history_value)
 
@@ -295,7 +295,7 @@ func _add_to_history() -> void:
 # Adds a history value to [_jump_history].
 # This function should NEVER be called manually.
 func _add_to_jump_history(target_position:int, target_collection:Blockflow.CollectionClass) -> void:
-	assert(bool(current_collection != null))
+	assert(bool(main_collection != null))
 	var jump_data := []
 	var history_from := []
 	var history_to := []
@@ -303,7 +303,7 @@ func _add_to_jump_history(target_position:int, target_collection:Blockflow.Colle
 	history_from.resize(_HistoryData.size())
 	history_to.resize(_HistoryData.size())
 	
-	history_from[_HistoryData.COLLECTION] = current_collection
+	history_from[_HistoryData.COLLECTION] = main_collection
 	history_from[_HistoryData.COMMAND_POSITION] = current_command_position
 	jump_data[_JumpHistoryData.FROM] = history_from
 	


### PR DESCRIPTION
This fixes an issue where the return index is incorrect. In this example the return fails:
![image](https://github.com/AnidemDex/Blockflow/assets/3470436/4bbadb95-97b9-4a43-acc0-10c7f7c0d229)
![image](https://github.com/AnidemDex/Blockflow/assets/3470436/a8228958-d0a5-42d9-a7a4-6a722e07fb21)

Swapping from "current_collection" to "main_collection" uses the correct index.

According to Dex,
> Main collection is the CommandCollection owner of the command
> And Current Collection is either that CommandCollection or a parent branch/group