### PR TITLE
Fix collection get_command not being staitc typed

### DIFF
--- a/collection.gd
+++ b/collection.gd
@@ -109,7 +109,7 @@ func clear() -> void:
 
 ## Get the command at [param position]. 
 ## [br]You can also use [method get] instead.
-func get_command(position:int):
+func get_command(position:int) -> Blockflow.CommandClass:
 	if position < collection.size():
 		return collection[position]
 	


### PR DESCRIPTION
4.2 made static typing even stricter so it caught on this