### PR TITLE
Fix duplicating a command resulting in sub-resources breaking 

### DIFF
--- a/collection.gd
+++ b/collection.gd
@@ -128,7 +128,7 @@ func get_command_position(command) -> int:
 	return collection.find(command)
 
 func get_duplicated():
-	var _duplicate = duplicate(true)
+	var _duplicate = duplicate()
 	var new_collection = []
 	for command in collection:
 		new_collection.append(command.get_duplicated())


### PR DESCRIPTION
For example, the character packed scene on Textalog's character command