### PR TITLE
Makes CommandProcessor change the way it adds to jump history.

### DIFF
--- a/command_processor.gd
+++ b/command_processor.gd
@@ -204,8 +204,9 @@ func go_to_previous_command() -> void:
 ## Jumps to a command, appending the call to jump history.
 func jump_to_command(command_position:int, on_collection:Blockflow.CollectionClass) -> void:
 	if not on_collection:
-		on_collection = current_collection
-	_add_to_jump_history(command_position, on_collection)
+		on_collection = main_collection
+	if on_collection != main_collection:
+		_add_to_jump_history(command_position, on_collection)
 	go_to_command_in_collection(command_position, on_collection)
 
 ## Returns to last [method jump_to_command] call according to [param return_value].


### PR DESCRIPTION
Modify jump_to_command to add to jump_history only when the passed collecction is different from current main_collection.

This should fix #113 

Supersedes #115 