### PR TITLE
Update CommandList layout

### DIFF
--- a/blockflow.gd
+++ b/blockflow.gd
@@ -34,6 +34,28 @@ static func get_default_command_scripts() -> Array:
 		
 	return commands
 
+# TODO: Custom commands made by the user that are not a script/resource file
+# and will live under a special folder.
+## Commands defined in 
+## ProjectSettings [constant PROJECT_SETTING_CUSTOM_COMMANDS]
+static func get_custom_commands() -> Array:
+	var commands := []
+	for command_path in ProjectSettings.get_setting(PROJECT_SETTING_CUSTOM_COMMANDS, []):
+		if not ResourceLoader.exists(command_path):
+			push_warning("!ResourceLoader.exists(%s) == true, continuing"%command_path)
+			continue
+		
+		# We can't guess the type, so let's load it as generic 
+		# and let the caller handle it.
+		var command:Resource = ResourceLoader.load(command_path)
+		if not command:
+			# HOW?
+			push_warning("CommandList: Resource at '%s' is not valid."%command_path)
+			continue
+		commands.append(command)
+		
+	return commands
+
 const PROJECT_SETTING_BLOCK_ICON_MIN_SIZE =\
 "blockflow/settings/editor/commands/icon_minimun_size"
 const BLOCK_ICON_MIN_SIZE = 32

--- a/blockflow.gd
+++ b/blockflow.gd
@@ -19,6 +19,21 @@ const PROJECT_SETTING_DEFAULT_COMMANDS =\
 const PROJECT_SETTING_CUSTOM_COMMANDS =\
 "blockflow/settings/commands/custom_commands"
 
+static func get_default_command_scripts() -> Array:
+	var commands := []
+	for command_path in DEFAULT_COMMAND_PATHS:
+		if not ResourceLoader.exists(command_path, "Script"):
+			push_warning("!ResourceLoader.exists(%s) == true, continuing"%command_path)
+			continue
+		
+		var command_script:Script = load(command_path) as Script
+		if not command_script:
+			push_warning("CommandList: Resource at '%s' is not an Script."%command_path)
+			continue
+		commands.append(command_script)
+		
+	return commands
+
 const PROJECT_SETTING_BLOCK_ICON_MIN_SIZE =\
 "blockflow/settings/editor/commands/icon_minimun_size"
 const BLOCK_ICON_MIN_SIZE = 32

--- a/command_processor.gd
+++ b/command_processor.gd
@@ -70,10 +70,12 @@ const Blockflow = preload("res://addons/blockflow/blockflow.gd")
 ## when owner is ready automatically.
 @export var start_on_ready:bool = false
 
-## Main [CommandCollection] used.
+## Main [CommandCollection] used. This value is gathered from
+## [method Command.get_main_collection].
 var main_collection:Blockflow.CommandCollectionClass
 
-## Current [Collection] used.
+## Current [Collection] used. This value is gathered from
+## [method Command.get_command_owner]
 var current_collection:Blockflow.CollectionClass
 
 ## Current executed [Command].
@@ -283,7 +285,9 @@ func _execute_command(command:Blockflow.CommandClass) -> void:
 	
 	command.execution_steps.call()
 
-
+# Adds a history value to [_history]
+# This function should NEVER be called manually.
+# Usually called when user goes from one command to another.
 func _add_to_history() -> void:
 	assert(bool(main_collection != null))
 	var history_value = []
@@ -294,7 +298,8 @@ func _add_to_history() -> void:
 
 
 # Adds a history value to [_jump_history].
-# This function should NEVER be called manually.
+# This function should NEVER be called manually. 
+# Usually called when user step to a command that has a different main collection.
 func _add_to_jump_history(target_position:int, target_collection:Blockflow.CollectionClass) -> void:
 	assert(bool(main_collection != null))
 	var jump_data := []

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -126,6 +126,12 @@ var command_text_color:Color :
 	set(value): return
 	get: return _get_color()
 
+## Command category where this command be grouped with
+## in editor.
+var command_category:StringName:
+	set(value): return
+	get: return _get_category()
+
 ## [CommandBlock] item assigned by editor.
 ## [br]This reference is assigned by Block Editor.
 var editor_block:TreeItem
@@ -333,6 +339,9 @@ func _get_description() -> String:
 
 func _get_color() -> Color:
 	return Color()
+
+func _get_category() -> StringName:
+	return &"Commands"
 
 func _can_hold_commands() -> bool:
 	return false

--- a/editor/command_list.gd
+++ b/editor/command_list.gd
@@ -4,11 +4,13 @@ extends PanelContainer
 const FALLBACK_ICON = preload("res://addons/blockflow/icons/false.svg")
 const Settings = preload("res://addons/blockflow/blockflow.gd")
 const CommandClass = preload("res://addons/blockflow/commands/command.gd")
+const EditorConst = preload("res://addons/blockflow/editor/constants.gd")
 
 class Category extends VBoxContainer:
 	const InspectorTools = preload("res://addons/blockflow/editor/inspector/inspector_tools.gd")
 	var title:Button
 	var container:VBoxContainer
+	var command_button_pressed_callback:Callable
 	
 	var commands := []
 	
@@ -25,6 +27,11 @@ class Category extends VBoxContainer:
 			Callable(),
 			Callable()
 		)
+		
+		if command_button_pressed_callback.is_valid():
+			command_button.pressed.connect(
+				command_button_pressed_callback.bind(command)
+				)
 		
 		command_button.text = command.command_name
 		
@@ -77,7 +84,7 @@ class Category extends VBoxContainer:
 		container.size_flags_vertical = Control.SIZE_EXPAND_FILL
 		add_child(container)
 
-var command_button_list_pressed:Callable
+var command_button_pressed_callback:Callable
 var scroll_container:ScrollContainer
 var category_container:VBoxContainer
 var misc_category:Category
@@ -106,6 +113,7 @@ func add_category(category_name:StringName) -> void:
 	if category_name in categories: return
 	
 	var category = Category.new()
+	category.command_button_pressed_callback = command_button_pressed_callback
 	category.title.text = category_name
 	category.title.icon = get_theme_icon("Object", "EditorIcons")
 	categories[category_name] = category

--- a/editor/command_list.gd
+++ b/editor/command_list.gd
@@ -107,6 +107,12 @@ func build_command_list() -> void:
 	
 	for command in Settings.get_default_command_scripts():
 		add_command(command)
+	
+	for command in Settings.get_custom_commands():
+		add_command(command)
+	
+	sort_categories()
+		
 
 
 func create_category_container() -> void:
@@ -115,6 +121,7 @@ func create_category_container() -> void:
 	category_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	category_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll_container.add_child(category_container)
+
 
 func add_category(category_name:StringName) -> void:
 	if category_name in categories: return
@@ -138,6 +145,19 @@ func add_command(command_obj:Object) -> void:
 		
 		category_node.add_command(command_obj)
 		return
+
+
+func sort_categories() -> void:
+	var c:Array = categories.keys()
+	c.erase(&"Commands")
+	c.sort()
+	for i in c.size():
+		var category:Node = categories[c[i]]
+		category_container.move_child(category, i)
+	
+	if &"Commands" in categories:
+		category_container.move_child(categories[&"Commands"], 0)
+
 
 func _notification(what: int) -> void:
 	match what:

--- a/editor/command_list.gd
+++ b/editor/command_list.gd
@@ -1,0 +1,140 @@
+@tool
+extends PanelContainer
+
+const FALLBACK_ICON = preload("res://addons/blockflow/icons/false.svg")
+const Settings = preload("res://addons/blockflow/blockflow.gd")
+const CommandClass = preload("res://addons/blockflow/commands/command.gd")
+
+class Category extends VBoxContainer:
+	const InspectorTools = preload("res://addons/blockflow/editor/inspector/inspector_tools.gd")
+	var title:Button
+	var container:VBoxContainer
+	
+	var commands := []
+	
+	func add_command(command:CommandClass) -> void:
+		if command in commands:
+			return
+		
+		commands.append(command)
+		
+		var command_button := Button.new()
+		command_button.alignment = HORIZONTAL_ALIGNMENT_LEFT
+		command_button.set_drag_forwarding(
+			command_button_get_drag_data.bind(command),
+			Callable(),
+			Callable()
+		)
+		
+		command_button.text = command.command_name
+		
+		var command_icon:Texture = command.command_icon
+		if not command_icon:
+			command_icon = FALLBACK_ICON
+		command_button.expand_icon = true
+		command_button.icon = command_icon
+		
+		container.add_child(command_button)
+		
+	func command_button_get_drag_data(at_position:Vector2, command:CommandClass):
+		if not command: return
+		
+		var drag_data = {&"type":&"resource", &"resource":null, &"from":self}
+		drag_data.resource = command.get_duplicated()
+		
+		var drag_preview = Button.new()
+		drag_preview.text = (drag_data.resource as Command).command_name
+		set_drag_preview(drag_preview)
+		
+		return drag_data
+	
+	func _toggle(button_pressed:bool) -> void:
+		container.visible = !container.visible
+	
+	func _notification(what: int) -> void:
+		match what:
+			NOTIFICATION_ENTER_TREE, NOTIFICATION_THEME_CHANGED:
+				var font := get_theme_font("bold","EditorFonts")
+				var font_size := get_theme_font_size("bold_size", "EditorFonts")
+				var sb := get_theme_stylebox("bg", "EditorInspectorCategory")
+				title.add_theme_font_override("font", font)
+				title.add_theme_constant_override("font_size", font_size)
+				title.add_theme_stylebox_override("normal", sb)
+				title.add_theme_stylebox_override("hover", sb)
+				title.add_theme_icon_override("checked", get_theme_icon("GuiTreeArrowRight", "EditorIcons"))
+				title.add_theme_icon_override("unchecked", get_theme_icon("GuiTreeArrowDown", "EditorIcons"))
+	
+	func _init() -> void:
+		title = CheckButton.new()
+		title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		title.text = "Category"
+		title.alignment = HORIZONTAL_ALIGNMENT_CENTER
+		title.toggled.connect(_toggle)
+		add_child(title)
+		
+		container = VBoxContainer.new()
+		container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		add_child(container)
+
+var command_button_list_pressed:Callable
+var scroll_container:ScrollContainer
+var category_container:VBoxContainer
+var misc_category:Category
+
+var categories:Dictionary = {}
+
+
+func build_command_list() -> void:
+	if is_instance_valid(category_container):
+		category_container.queue_free()
+	categories.clear()
+	create_category_container()
+	
+	for command in Settings.get_default_command_scripts():
+		add_command(command)
+
+
+func create_category_container() -> void:
+	if is_instance_valid(category_container): return
+	category_container = VBoxContainer.new()
+	category_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	category_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll_container.add_child(category_container)
+
+func add_category(category_name:StringName) -> void:
+	if category_name in categories: return
+	
+	var category = Category.new()
+	category.title.text = category_name
+	category.title.icon = get_theme_icon("Object", "EditorIcons")
+	categories[category_name] = category
+	category_container.add_child(category)
+
+
+func add_command(command_obj:Object) -> void:
+	if command_obj is Script:
+		command_obj = command_obj.new()
+	
+	if command_obj is CommandClass:
+		var category:StringName = command_obj.command_category
+		add_category(category)
+		var category_node:Node = categories.get(category, null)
+		
+		category_node.add_command(command_obj)
+		return
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_ENTER_TREE, NOTIFICATION_THEME_CHANGED:
+			# TODO: Add a background stylebox
+			return
+
+func _init() -> void:
+	size_flags_vertical = Control.SIZE_EXPAND_FILL
+	custom_minimum_size = Vector2(128, 64)
+	
+	scroll_container = ScrollContainer.new()
+	scroll_container.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	scroll_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	add_child(scroll_container)

--- a/editor/command_list.gd
+++ b/editor/command_list.gd
@@ -70,6 +70,13 @@ class Category extends VBoxContainer:
 				title.add_theme_stylebox_override("hover", sb)
 				title.add_theme_icon_override("checked", get_theme_icon("GuiTreeArrowRight", "EditorIcons"))
 				title.add_theme_icon_override("unchecked", get_theme_icon("GuiTreeArrowDown", "EditorIcons"))
+				title.add_theme_icon_override("checked_disabled", get_theme_icon("GuiTreeArrowRight", "EditorIcons"))
+				title.add_theme_icon_override("unchecked_disabled", get_theme_icon("GuiTreeArrowDown", "EditorIcons"))
+			
+			9003:
+				propagate_call("set", ["disabled", true])
+			9004:
+				propagate_call("set", ["disabled", false])
 	
 	func _init() -> void:
 		title = CheckButton.new()

--- a/editor/constants.gd
+++ b/editor/constants.gd
@@ -1,0 +1,8 @@
+
+# Editor specific starts in 9000, 9001 and 9002 are reserved
+# https://github.com/godotengine/godot/blob/4.0.1-stable/scene/main/node.h#L298
+
+enum {
+	NOTIFICATION_EDITOR_DISABLED = 9003,
+	NOTIFICATION_EDITOR_ENABLED = 9004,
+}

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -5,6 +5,8 @@ const Blockflow = preload("res://addons/blockflow/blockflow.gd")
 const CollectionDisplayer = preload("res://addons/blockflow/editor/displayer.gd")
 const CommandList = preload("res://addons/blockflow/editor/command_list.gd")
 
+const Constants = preload("res://addons/blockflow/editor/constants.gd")
+
 enum _ItemPopup {
 	MOVE_UP, 
 	MOVE_DOWN, 
@@ -75,6 +77,11 @@ var _file_menu:PopupMenu
 var _editor_file_dialog:EditorFileDialog
 var _file_dialog:FileDialog
 
+func disable() -> void:
+	propagate_notification(Constants.NOTIFICATION_EDITOR_DISABLED)
+
+func enable() -> void:
+	propagate_notification(Constants.NOTIFICATION_EDITOR_ENABLED)
 
 func close() -> void:
 	collection_displayer.build_tree(null)
@@ -87,6 +94,7 @@ func close() -> void:
 	title_label.text = ""
 	update_history()
 	show_help_panel()
+	disable()
 
 
 func edit(object:Object) -> void:
@@ -106,6 +114,7 @@ func edit_collection(collection:Blockflow.CollectionClass) -> void:
 		)
 		
 		show_help_panel()
+		disable()
 		return
 		
 	var load_function:Callable = collection_displayer.build_tree
@@ -125,6 +134,7 @@ func edit_collection(collection:Blockflow.CollectionClass) -> void:
 		
 	path_hint = _current_collection.resource_path
 	hide_help_panel()
+	enable()
 	_file_menu.set_item_disabled(_file_menu.get_item_index(ToolbarFileMenu.CLOSE_COLLECTION), false)
 	
 	history[path_hint.get_file()] = path_hint
@@ -607,6 +617,18 @@ func _notification(what: int) -> void:
 			_help_panel_load_btn.icon = get_theme_icon("Object", "EditorIcons")
 			_help_panel_new_btn.icon = get_theme_icon("Load", "EditorIcons")
 			title_label.add_theme_stylebox_override("normal", get_theme_stylebox("ContextualToolbar", "EditorStyles"))
+		
+		NOTIFICATION_POST_ENTER_TREE,NOTIFICATION_VISIBILITY_CHANGED:
+			if not visible: return
+			
+			if edited_object:
+				hide_help_panel()
+				enable()
+				return
+			
+			show_help_panel()
+			disable()
+		
 		NOTIFICATION_PREDELETE:
 			# Clean clipboard
 			command_clipboard = null
@@ -720,8 +742,6 @@ func _init() -> void:
 	_help_panel_load_btn.text = "Load Collection"
 	_help_panel_load_btn.pressed.connect(_request_open)
 	hb.add_child(_help_panel_load_btn)
-	
-	show_help_panel()
 	
 	if Engine.is_editor_hint():
 # https://github.com/godotengine/godot/issues/73525#issuecomment-1606067249

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -3,7 +3,7 @@ extends PanelContainer
 
 const Blockflow = preload("res://addons/blockflow/blockflow.gd")
 const CollectionDisplayer = preload("res://addons/blockflow/editor/displayer.gd")
-const CommandList = preload("res://addons/blockflow/command_list.gd")
+const CommandList = preload("res://addons/blockflow/editor/command_list.gd")
 
 enum _ItemPopup {
 	MOVE_UP, 

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -389,10 +389,10 @@ func _get_file_dialog() -> ConfirmationDialog:
 	return _file_dialog
 
 
-func _command_button_list_pressed(command_script:Script) -> void:
+func _command_button_list_pressed(command:Blockflow.CommandClass) -> void:
 	var command_idx:int = -1
 	var tree_item:TreeItem = collection_displayer.get_selected()
-	var new_command:Blockflow.CommandClass = command_script.new()
+	var new_command:Blockflow.CommandClass = command.get_duplicated()
 	var in_collection:Blockflow.CollectionClass = _current_collection
 	if tree_item:
 		var selected:Blockflow.CommandClass = collection_displayer.get_selected().get_metadata(0) as Blockflow.CommandClass
@@ -681,7 +681,7 @@ func _init() -> void:
 	
 	command_list = CommandList.new()
 	command_list.name = "CommandList"
-	command_list.command_button_list_pressed = _command_button_list_pressed
+	command_list.command_button_pressed_callback = _command_button_list_pressed
 	left_section.add_child(command_list)
 	
 	var recents := VBoxContainer.new()


### PR DESCRIPTION
Updates `EditorCommandList` (yeah, it has a name now) layout, adding collapsible categories.
![image](https://github.com/AnidemDex/Blockflow/assets/7025991/dc2396eb-5b6d-4086-a00f-060011ca03ee)![image](https://github.com/AnidemDex/Blockflow/assets/7025991/3e51b175-6bdf-4510-9a9e-ff324f6dd930)

The category name definition is on `Command.command_category` property (and `_get_category` aswell, since is supposed to be defined in the command and not in the file that command serializes).
fix #108 