### PR TITLE
Display resource path rather than the incomprehensible object in the call/set command hint

### DIFF
--- a/commands/command_call.gd
+++ b/commands/command_call.gd
@@ -33,7 +33,12 @@ func _get_name() -> StringName:
 
 
 func _get_hint() -> String:
-	var hint_str = method + "(" + str(args).trim_prefix("[").trim_suffix("]") + ")"
+	var properties = ""
+	for arg in args:
+		if arg is Resource:
+			arg = "<" + arg.resource_path + ">"
+		properties += str(arg) + ", "
+	var hint_str = method + "(" + properties.trim_suffix(", ") + ")"
 	if target != NodePath():
 		hint_str += " on " + str(target)
 	return hint_str

--- a/commands/command_set.gd
+++ b/commands/command_set.gd
@@ -82,6 +82,8 @@ func _get_hint() -> String:
 		hint += str(target)+"."
 	
 	var fake_value := str(value)
+	if value is Resource:
+		fake_value = "<" + value.resource_path + ">"
 	if fake_value.is_empty():
 		fake_value = "<Not Defined>"
 	var operator = "="


### PR DESCRIPTION
Far more readable to just provide the path to resource:

![image](https://github.com/AnidemDex/Blockflow/assets/3470436/a1afb6d9-7c71-4867-845e-08dff3037c8a)
