### PR TITLE
Create editor layout

### DIFF
--- a/commands/command.gd
+++ b/commands/command.gd
@@ -138,7 +138,7 @@ var editor_block:TreeItem
 
 ## Layout data used by editor. This data is saved in editor
 ## and is not shared between projects.
-var editor_layout:Dictionary
+var editor_state:Dictionary
 
 ## Target node that [member target] points to. This value is assigned by
 ## [member command_manager] before command execution if [member target] is a

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -136,6 +136,10 @@ var command_category:StringName:
 ## [br]This reference is assigned by Block Editor.
 var editor_block:TreeItem
 
+## Layout data used by editor. This data is saved in editor
+## and is not shared between projects.
+var editor_layout:Dictionary
+
 ## Target node that [member target] points to. This value is assigned by
 ## [member command_manager] before command execution if [member target] is a
 ## valid path, else node assigned in

--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -99,6 +99,12 @@ func _get_plugin_name() -> String:
 func _get_plugin_icon():
 	return Icon
 
+func _save_external_data() -> void:
+	queue_save_layout()
+
+func _get_window_layout(configuration: ConfigFile) -> void:
+	block_editor.save_layout()
+
 func _define_toaster() -> void:
 	var dummy = Control.new()
 	dummy.name = "Dummy"
@@ -117,6 +123,7 @@ func _project_settings_changed() -> void:
 	block_editor.command_list.build_command_list()
 
 func _exit_tree():
+	queue_save_layout()
 	block_editor.queue_free()
 	
 	remove_resource_conversion_plugin(timeline_converter)

--- a/editor/command_block/block.gd
+++ b/editor/command_block/block.gd
@@ -105,6 +105,8 @@ func update() -> void:
 	set_text(ColumnPosition.INDEX_COLUMN, position_hint)
 	set_custom_color(ColumnPosition.INDEX_COLUMN, disabled_color)
 	set_text_alignment(ColumnPosition.INDEX_COLUMN, HORIZONTAL_ALIGNMENT_RIGHT)
+	
+	collapsed = command.editor_state.get("folded", false)
 
 
 func set_command(value:CommandClass) -> void:

--- a/editor/constants.gd
+++ b/editor/constants.gd
@@ -6,3 +6,5 @@ enum {
 	NOTIFICATION_EDITOR_DISABLED = 9003,
 	NOTIFICATION_EDITOR_ENABLED = 9004,
 }
+
+const DEFAULT_LAYOUT_FILE = "res://.godot/editor/block_editor_cache.cfg"

--- a/editor/displayer.gd
+++ b/editor/displayer.gd
@@ -33,17 +33,12 @@ func build_tree(object:Object) -> void:
 
 func _reload() -> void:
 	clear()
-	for command in displayed_commands:
-		if command.collection_changed.is_connected(_reload):
-			command.collection_changed.disconnect(_reload)
 	
 	displayed_commands = []
 	
 	if not _current_collection:
 		last_selected_command = null
 		return
-	# Force generation of the tree
-	Blockflow.generate_tree(_current_collection)
 	
 	var min_width:int = 24 + Blockflow.BLOCK_ICON_MIN_SIZE
 	set_column_custom_minimum_width(CommandBlock.ColumnPosition.NAME_COLUMN, min_width*columns)
@@ -59,9 +54,6 @@ func _reload() -> void:
 	for command in _current_collection:
 		_add_command(command, root)
 	
-	for command in displayed_commands:
-		if not command.collection_changed.is_connected(_reload):
-			command.collection_changed.connect(_reload)
 	root.call_recursive("update")
 	if last_selected_command and is_instance_valid(last_selected_command.editor_block):
 		last_selected_command.editor_block.select(0)

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -1,6 +1,20 @@
 @tool
 extends PanelContainer
 
+class StateLayout:
+	var folded_commands:Array[int] = []
+	var last_selected_command_position:int = -1
+	
+	func to_dict() -> Dictionary:
+		return {
+			"folded_commands":folded_commands,
+			"last_selected_command_position":last_selected_command_position,
+		}
+	
+	func from_dict(val:Dictionary) -> void:
+		folded_commands = val.get("folded_commands", [])
+		last_selected_command_position = val.get("last_selected_command_position", -1)
+
 const Blockflow = preload("res://addons/blockflow/blockflow.gd")
 const CollectionDisplayer = preload("res://addons/blockflow/editor/displayer.gd")
 const CommandList = preload("res://addons/blockflow/editor/command_list.gd")
@@ -53,6 +67,8 @@ var toast_callback:Callable
 var history:Dictionary = {}
 
 var edited_object:Object
+
+var state:StateLayout
 
 # https://github.com/godotengine/godot/blob/4.0-stable/editor/editor_inspector.cpp#L3977
 var command_clipboard:Blockflow.CommandClass:


### PR DESCRIPTION
This is the first PR that may add the basis for editor layout for the current and future extra editors.

Basically it creates a section in a file, saving some data and restoring it when the resource is edited.

fix #98 

Note: Due the way it was done, selection between reloads may be lost, a new pr must be done to restore this (which probably may remove `Displayer.last_selected_command`