### PR TITLE
Create shortcut behavior

### DIFF
--- a/editor/constants.gd
+++ b/editor/constants.gd
@@ -8,3 +8,5 @@ enum {
 }
 
 const DEFAULT_LAYOUT_FILE = "res://.godot/editor/block_editor_cache.cfg"
+
+const SHORTCUT_DUPLICATE = preload("res://addons/blockflow/editor/shortcuts/duplicate.tres")

--- a/editor/constants.gd
+++ b/editor/constants.gd
@@ -10,3 +10,4 @@ enum {
 const DEFAULT_LAYOUT_FILE = "res://.godot/editor/block_editor_cache.cfg"
 
 const SHORTCUT_DUPLICATE = preload("res://addons/blockflow/editor/shortcuts/duplicate.tres")
+const SHORTCUT_DELETE = preload("res://addons/blockflow/editor/shortcuts/delete.tres")

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -509,6 +509,7 @@ func _collection_displayer_item_mouse_selected(_position:Vector2, button_index:i
 		_item_popup.add_item("Duplicate", _ItemPopup.DUPLICATE)
 		_item_popup.set_item_shortcut(_item_popup.get_item_index(_ItemPopup.DUPLICATE), Constants.SHORTCUT_DUPLICATE)
 		_item_popup.add_item("Remove", _ItemPopup.REMOVE)
+		_item_popup.set_item_shortcut(_item_popup.get_item_index(_ItemPopup.REMOVE), Constants.SHORTCUT_DELETE)
 		_item_popup.add_separator()
 		
 		_item_popup.add_item("Copy", _ItemPopup.COPY)
@@ -731,7 +732,13 @@ func _shortcut_input(event: InputEvent) -> void:
 		duplicate_command(command, command_idx + 1)
 		accept_event()
 		return
-		
+	
+	if Constants.SHORTCUT_DELETE.matches_event(event):
+		remove_command(command)
+		accept_event()
+		return
+	
+	
 
 func _notification(what: int) -> void:
 	match what:

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -507,6 +507,7 @@ func _collection_displayer_item_mouse_selected(_position:Vector2, button_index:i
 		_item_popup.set_item_disabled(1, !can_move_down)
 		_item_popup.add_separator()
 		_item_popup.add_item("Duplicate", _ItemPopup.DUPLICATE)
+		_item_popup.set_item_shortcut(_item_popup.get_item_index(_ItemPopup.DUPLICATE), Constants.SHORTCUT_DUPLICATE)
 		_item_popup.add_item("Remove", _ItemPopup.REMOVE)
 		_item_popup.add_separator()
 		
@@ -709,6 +710,28 @@ func _current_collection_modified() -> void:
 	
 	collection_displayer.build_tree(_current_collection)
 
+func _shortcut_input(event: InputEvent) -> void:
+	var focus_owner:Control = get_viewport().gui_get_focus_owner()
+	if not is_instance_valid(focus_owner):
+		return
+	
+	if not (collection_displayer.is_ancestor_of(focus_owner) or collection_displayer == focus_owner):
+		return
+	
+	if not is_instance_valid(collection_displayer.get_selected()):
+		return
+	
+	var command:Blockflow.CommandClass = collection_displayer.get_selected().get_metadata(0)
+	if not command:
+		return
+	
+	var command_idx:int = command.index
+	
+	if Constants.SHORTCUT_DUPLICATE.matches_event(event):
+		duplicate_command(command, command_idx + 1)
+		accept_event()
+		return
+		
 
 func _notification(what: int) -> void:
 	match what:

--- a/editor/shortcuts/delete.tres
+++ b/editor/shortcuts/delete.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Shortcut" load_steps=2 format=3 uid="uid://c5nkhna76x40d"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_eio0l"]
+device = -1
+pressed = true
+keycode = 4194312
+
+[resource]
+events = [SubResource("InputEventKey_eio0l")]

--- a/editor/shortcuts/duplicate.tres
+++ b/editor/shortcuts/duplicate.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Shortcut" load_steps=2 format=3 uid="uid://dfrq7k81nnflh"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_ap11u"]
+device = -1
+ctrl_pressed = true
+pressed = true
+keycode = 68
+unicode = 100
+
+[resource]
+events = [SubResource("InputEventKey_ap11u")]


### PR DESCRIPTION
This PR aims to fix #100 .

Shortcuts are created under `editor/shortcuts` folder, registered under `editor/constants.gd` file and used in `editor/editor.gd`, replicating what `Editor.item_popup`  does:
https://github.com/AnidemDex/Blockflow/blob/bd2e06bc0af5641d86b565bff46a00f63781c1d3/editor/editor.gd#L445-L465

So, in the future, shortcuts should follow a similar behavior: defining themselves in `shortcuts` as `Shortcut` and being used with constant values.