### PR TITLE
Select the moved/duplicated command automatically

### DIFF
--- a/editor/displayer.gd
+++ b/editor/displayer.gd
@@ -27,7 +27,6 @@ func build_tree(object:Object) -> void:
 		collection = object as CollectionClass
 	
 	_current_collection = collection
-	last_selected_command = null
 	_reload()
 
 
@@ -57,6 +56,7 @@ func _reload() -> void:
 	root.call_recursive("update")
 	if last_selected_command and is_instance_valid(last_selected_command.editor_block):
 		last_selected_command.editor_block.select(0)
+		ensure_cursor_is_visible()
 	else:
 		last_selected_command = null
 	

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -206,7 +206,8 @@ func add_command(command:Blockflow.CommandClass, at_position:int = -1, to_collec
 	
 	
 	var action_name:String = "Add command '%s'" % [command.command_name]
-	
+	collection_displayer.last_selected_command = command
+	state.last_selected_command_position = at_position
 	if Engine.is_editor_hint():
 		editor_undoredo.create_action(action_name)
 		
@@ -262,6 +263,7 @@ func move_command(command:Blockflow.CommandClass, to_position:int, from_collecti
 
 	var from_position:int = from_collection.get_command_position(command)
 	var action_name:String = "Move command '%s'" % [command.command_name]
+	collection_displayer.last_selected_command = command
 	if Engine.is_editor_hint():
 		if from_collection == to_collection:
 			editor_undoredo.create_action(action_name, 0, from_collection)
@@ -304,9 +306,8 @@ func duplicate_command(command:Blockflow.CommandClass, to_index:int) -> void:
 	
 	var action_name:String = "Duplicate command '%s'" % [command.command_name]
 	var duplicated_command = command.get_duplicated()
-	collection_displayer.last_selected_command = command
+	collection_displayer.last_selected_command = duplicated_command
 	var idx = to_index if to_index > -1 else command_collection.size()
-	
 	if Engine.is_editor_hint():
 		editor_undoredo.create_action(action_name)
 		editor_undoredo.add_do_method(command_collection, "insert", duplicated_command, idx)
@@ -414,7 +415,7 @@ func restore_layout() -> void:
 		return
 	
 	state.from_dict(layout.get_value(_current_collection.resource_path, "state", {}))
-	
+
 	for pos in state.folded_commands:
 		var command = _current_collection.get_command(pos)
 		command.editor_state["folded"] = true
@@ -486,7 +487,7 @@ func _command_button_list_pressed(command:Blockflow.CommandClass) -> void:
 				command_idx = selected.index + 1
 				in_collection = selected.get_command_owner()
 			
-			collection_displayer.last_selected_command = new_command
+	collection_displayer.last_selected_command = new_command
 	add_command(new_command, command_idx, in_collection)
 
 


### PR DESCRIPTION
This system seemed to be unfinished, so I took it and made it work.
A few notes:
* Doesn't work with "undo/redo" properly, would have to look into it
* It remembers the command rather than index, there's a #FIXME comment mentioning that