### PR TITLE
Define fake "singleton" structure for plugin

### DIFF
--- a/core/constants.gd
+++ b/core/constants.gd
@@ -1,3 +1,7 @@
+## Plugin constants
+
+const NAME = &"Blockflow"
+const PLUGIN_NAME = &"BlockflowPlugin"
 
 const COMMAND_FOLDER = &"res://addons/blockflow/commands"
 

--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -97,7 +97,7 @@ func _has_main_screen() -> bool:
 
 
 func _get_plugin_name() -> String:
-	return "Blockflow"
+	return Constants.NAME
 
 func _get_plugin_icon():
 	return theme.get_icon("plugin_icon_flat", "PluginIcons")

--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -166,3 +166,7 @@ func _init() -> void:
 	project_settings_changed.connect(_project_settings_changed)
 	
 	debugger = BlockflowDebugger.new()
+	
+	# Add the plugin to the list when we're created as soon as possible.
+	# Existing doesn't mean that plugin is ready, be careful with that.
+	Engine.set_meta(Constants.PLUGIN_NAME, self)


### PR DESCRIPTION
This PR aims to define the way fake plugin _singleton_ are created (we'll need this later), applying it to plugin script (since the plugin has to be unique?).

It should not affect anything, since it doesn't modify anything related to command processing.