### PR TITLE
Update CommandRecord registration.

### DIFF
--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -150,9 +150,9 @@ func _init() -> void:
 	
 	debugger = BlockflowDebugger.new()
 	
+	command_record = Blockflow.CommandRecord.get_record()
+	project_settings_changed.connect(command_record.reload_from_project_settings)
+	
 	# Add the plugin to the list when we're created as soon as possible.
 	# Existing doesn't mean that plugin is ready, be careful with that.
 	Engine.set_meta(Constants.PLUGIN_NAME, self)
-	
-	command_record = Blockflow.CommandRecord.new()
-	project_settings_changed.connect(command_record.reload_from_project_settings)

--- a/editor/editor.gd
+++ b/editor/editor.gd
@@ -63,6 +63,7 @@ var collection_displayer:CollectionDisplayer
 var command_list:CommandList
 var title_label:Label
 var template_generator:TemplateGenerator
+var command_record:Blockflow.CommandRecord
 
 var edit_callback:Callable
 var toast_callback:Callable
@@ -916,5 +917,7 @@ func _init() -> void:
 		_file_dialog = FileDialog.new()
 		_file_dialog.file_selected.connect(_editor_file_dialog_file_selected)
 		add_child(_file_dialog)
+	
+	command_record = Blockflow.CommandRecord.new()
 	
 	Engine.set_meta("Blockflow_main_editor", self)


### PR DESCRIPTION
Move the creation of CommandRecord from the editor plugin to BlockEditor. Add `command_record` to BlockEditor.

This was made to ensure BlockEditor works in runtime for debug purposes and (possibly) works as a standalone tool.