### PR TITLE
Update editor view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres loosely to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!--
+FYI here's a hint about versioning:
+
+    Added for new features.
+    Changed for changes in existing functionality.
+    Deprecated for soon-to-be removed features.
+    Removed for now removed features.
+    Fixed for any bug fixes.
+    Security in case of vulnerabilities.
+
+-->
+
 ## Unreleased 
 ### Added
 - More documentation about project structure and usage.
+- A simple example. It just prints something in console.
+- **Multiple selection of commands**. This is part of our new UI.
+- `Command` properties:
+  - `block_name` as `command_name` alias to change the display name in editor.
+  - `block_color` to tint the block representation in editor.
+  - `block_icon` to define the texture used in the block representation in editor.
 ### Changed
 - `Set` command behavior. Now includes more operations and hints to be done in the command - [#153](https://github.com/AnidemDex/Blockflow/pull/153).
+- **Editor UI**. We now have a new custom displayer.
+- `Command.background_color` to `Command.block_color`.
+- `Command.command_hint_icon` to `Command.block_icon`
 ### Deprecated
 - `Set.PlusOperables` constant. Now `Operables` is used instead.
+- `Command.Group`. Unused constant.
+- `Command.background_color`.
+- `Command.command_hint_icon`.
+- `Command.command_text_color`.
+- `Command.defines_default_branches`.
+- `Command.can_be_moved`.
+- `Command.go_to_branch()`.
+- `Command._get_hint_icon()`.
+- `Command._can_be_selected()`.
+- `Command._defines_default_branches()`.
+- `Command._get_default_branch_for()`.
+### Removed
+- Old `Timeline` references. You _really_ should not be using those, they were not meant to exist in 1.0 but it was keep to preserve an older project stability.
 ## \[[1.1](https://github.com/AnidemDex/Blockflow/releases/tag/1.1)] 2024-06-02
 ### Added
 - Copy and paste command functionality - [#105](https://github.com/AnidemDex/Blockflow/pull/105).

--- a/collection.gd
+++ b/collection.gd
@@ -181,9 +181,16 @@ func _notification(what: int) -> void:
 			command.index = command_index
 			command.weak_collection = weak_collection
 
+func _validate_property(property: Dictionary) -> void:
+	if property.name == "collection":
+		if collection.is_empty():
+			property.usage = PROPERTY_USAGE_ALWAYS_DUPLICATE
+		else:
+			property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_ALWAYS_DUPLICATE
+
 func _get_property_list() -> Array:
 	var p:Array = []
-	p.append({"name":"collection", "type":TYPE_ARRAY, "usage":PROPERTY_USAGE_NO_EDITOR|PROPERTY_USAGE_SCRIPT_VARIABLE|PROPERTY_USAGE_ALWAYS_DUPLICATE})
+	p.append({"name":"collection", "type":TYPE_ARRAY, "usage":PROPERTY_USAGE_NO_EDITOR|PROPERTY_USAGE_ALWAYS_DUPLICATE})
 	return p
 
 func _to_string() -> String:

--- a/collection.gd
+++ b/collection.gd
@@ -151,6 +151,10 @@ func size() -> int:
 func is_empty() -> bool:
 	return collection.is_empty()
 
+## Forces an update to contained data.
+func update() -> void:
+	_notify_changed()
+
 func _notify_changed() -> void: 
 	notification(NOTIFICATION_UPDATE_STRUCTURE)
 	Blockflow.generate_tree(self)

--- a/collection.gd
+++ b/collection.gd
@@ -188,11 +188,6 @@ func _validate_property(property: Dictionary) -> void:
 		else:
 			property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_ALWAYS_DUPLICATE
 
-func _get_property_list() -> Array:
-	var p:Array = []
-	p.append({"name":"collection", "type":TYPE_ARRAY, "usage":PROPERTY_USAGE_NO_EDITOR|PROPERTY_USAGE_ALWAYS_DUPLICATE})
-	return p
-
 func _to_string() -> String:
 	return "<Collection:%d>" % get_instance_id()
 

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -48,16 +48,8 @@ const Branch = preload("res://addons/blockflow/commands/branch.gd")
 		notify_property_list_changed()
 	get: return target
 
-## Execution steps that will be called to execute the command behaviour.
-## By default, it uses [method _execution_steps], you can override
-## that method to define your own steps.
-var execution_steps:Callable = _execution_steps
-
-## [CommandProcessor] node that is executing this command.
-## This value is assigned by its current command manager and
-## should not be assigned manually.
-var command_manager:Node
-
+#region COMMAND DATA
+@export_group("Command Data")
 ## The command name. Use [method _get_name] to define the name.
 ##[br]Command name is used by editor, it'll displayed in item the first column
 ## next to command icon.
@@ -67,7 +59,7 @@ var command_manager:Node
 ## func _get_name() -> StringName:
 ##     return &"Example Command"
 ## [/codeblock]
-var command_name:StringName :
+@export var command_name:StringName :
 	set(value): return
 	get: return _get_name()
 
@@ -78,9 +70,19 @@ var command_name:StringName :
 ## func _get_icon() -> Texture:
 ##     return load("res://icon.svg")
 ## [/codeblock]
-var command_icon:Texture :
+@export var command_icon:Texture :
 	set(value): return
 	get: return _get_icon()
+
+## Command description is used by editor and will be show as tooltip hint.
+## [br]Use [method _get_description] to define the description.
+## [codeblock]
+## func _get_description() -> String:
+##     return "This is an example command"
+## [/codeblock]
+@export_multiline var command_description:String :
+	set(value): return
+	get: return _get_description()
 
 ## Command hint. Use [method _get_hint] to define the command hint.
 ## [br]It will be displayed on command item middle column, 
@@ -135,16 +137,6 @@ var command_hint_icon:Texture :
 	set(value): return
 	get: return _get_hint_icon()
 
-## Command description is used by editor and will be show as tooltip hint.
-## [br]Use [method _get_description] to define the description.
-## [codeblock]
-## func _get_description() -> String:
-##     return "This is an example command"
-## [/codeblock]
-var command_description:String :
-	set(value): return
-	get: return _get_description()
-
 ## The color of this command's text
 ## Used by the Comment command to fade the text out
 ## @deprecated
@@ -152,11 +144,57 @@ var command_text_color:Color :
 	set(value): return
 	get: return _get_color()
 
-## Command category where this command be grouped with
-## in editor.
-var command_category:StringName:
-	set(value): return
-	get: return _get_category()
+@export_group(&"Block", &"block_")
+## Used as [member command_name] alias. Defined value will replace
+## the text displayed in the block representation.
+@export var block_name:String:
+	set(value):
+		if block_name == value:
+			return
+		block_name = value
+		emit_changed()
+
+## Color used to tint the vertical bar and background of the
+## block representation.[br]
+## Possible values are:[br]
+## [color=red]- Red [/color][br]
+## [color=yellow]- Yellow[/color][br]
+## [color=green]- Green[/color][br]
+## [color=aqua]- Aqua[/color][br]
+## [color=blue]- Blue[/color][br]
+## [color=purple]- Purple[br][/color]
+## [color=pink]- Pink[br][/color]
+## - Custom[br]
+## If [code]Custom[/code] is selected, you can define a custom color
+## value with [member block_custom_color].[br]
+## All values, except [code]Custom[/code] will be automatically
+## adjusted according their background.
+@export var block_color:int:
+	set(value):
+		if block_color == value:
+			return
+		block_color = value
+		emit_changed()
+		notify_property_list_changed()
+
+## Color used to tint the vertical bar and background of the
+## block representation.[br]
+## This value is used when [member block_color] value is 
+## [code]Custom (8)[/code].
+@export var block_custom_color:Color:
+	set(value):
+		if block_custom_color == value:
+			return
+		block_custom_color = value
+		emit_changed()
+
+## Texture icon used in the block representation.
+@export var block_icon:Texture:
+	set(value):
+		if block_icon == value:
+			return
+		block_icon = value
+		emit_changed()
 
 ## [CommandBlock] item assigned by editor.
 ## [br]This reference is assigned by Block Editor.
@@ -165,6 +203,12 @@ var editor_block:Object
 ## Layout data used by editor. This data is saved in editor
 ## and is not shared between projects.
 var editor_state:Dictionary
+#endregion
+
+## Execution steps that will be called to execute the command behaviour.
+## By default, it uses [method _execution_steps], you can override
+## that method to define your own steps.
+var execution_steps:Callable = _execution_steps
 
 ## Target node that [member target] points to. This value is assigned by
 ## [member command_manager] before command execution if [member target] is a
@@ -467,51 +511,113 @@ func _notification(what: int) -> void:
 						collection.remove_at(command_index)
 						collection.insert(command_index, branch)
 
+
+func _set(property: StringName, value: Variant) -> bool:
+	return false
+
+
 func _get(property: StringName):
 	match property:
-		"advanced/name":
-			return ""
-		"debug/position":
+		#region debug
+		&"debug/position":
 			return position
-		"debug/index":
+		&"debug/index":
 			return index
-		"debug/owner":
+		&"debug/owner":
+			return weak_owner
 			return get_command_owner()
-		"debug/main_collection":
+		&"debug/main_collection":
+			return weak_collection
 			return get_main_collection()
-		_:
+		#endregion
+
+func _property_can_revert(property: StringName) -> bool:
+	return property.begins_with(&"block_")
+
+func _property_get_revert(property: StringName) -> Variant:
+	match property:
+		&"block_name":
+			return ""
+		&"block_color":
+			return 0
+		&"block_custom_color":
+			return Color()
+		&"block_icon":
+			return null
+	return
+
+func _validate_property(property: Dictionary) -> void:
+	super(property)
+	
+	var property_name:StringName = property.get(&"name", &"")
+	
+	if property_name.begins_with(&"command_"):
+		const cmd_data = [
+			&"command_name",
+			&"command_icon",
+			&"command_description",
+			&"command_hint",
+			&"command_category",
+		]
+		if not property_name in cmd_data: return
+		
+		property[&"usage"] = PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_EDITOR
+		return
+	
+	match property_name:
+		&"resource_local_to_scene", &"resource_path", &"resource_name", &"script":
+			property[&"usage"] |= PROPERTY_USAGE_READ_ONLY
 			return
+		
+		&"block_name":
+			property[&"hint"] = PROPERTY_HINT_PLACEHOLDER_TEXT
+			property[&"hint_string"] = command_name
+			
+			if block_name.is_empty():
+				property[&"usage"] = PROPERTY_USAGE_EDITOR
+			else:
+				property[&"usage"] = PROPERTY_USAGE_DEFAULT
+		
+		&"block_color":
+			property[&"hint"] = PROPERTY_HINT_ENUM
+			property[&"hint_string"] = "[None],Red,Yellow,Green,Aqua,Blue,Purple,Pink,Custom"
+			
+			if block_color <= 0:
+				property[&"usage"] = PROPERTY_USAGE_EDITOR
+			else:
+				property[&"usage"] = PROPERTY_USAGE_DEFAULT
+			
+		&"block_custom_color":
+			property[&"hint"] = PROPERTY_HINT_COLOR_NO_ALPHA
+			
+			if block_color < 8:
+				property[&"usage"] = PROPERTY_USAGE_NONE
+			else:
+				property[&"usage"] = PROPERTY_USAGE_DEFAULT
 
 func _get_property_list() -> Array[Dictionary]:
 	var p:Array[Dictionary] = []
-	p.append(
-		{
-			"name":"advanced/name",
-			"type":TYPE_STRING,
-			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
-			"hint":PROPERTY_HINT_PLACEHOLDER_TEXT,
-			"hint_string":command_name,
-		})
+	
 	if OS.is_stdout_verbose():
 		p.append({
-				"name":"debug/position",
-				"type":TYPE_INT,
-				"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+			&"name":&"debug/position",
+			&"type":TYPE_INT,
+			&"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
 		})
 		p.append({
-			"name":"debug/index",
-			"type":TYPE_INT,
-			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY
+			&"name":&"debug/index",
+			&"type":TYPE_INT,
+			&"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY
 		})
 		p.append({
-			"name":"debug/owner",
-			"type":TYPE_OBJECT,
-			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+			&"name":&"debug/owner",
+			&"type":TYPE_OBJECT,
+			&"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
 		})
 		p.append({
-			"name":"debug/main_collection",
-			"type":TYPE_OBJECT,
-			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+			&"name":&"debug/main_collection",
+			&"type":TYPE_OBJECT,
+			&"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
 		})
 	return p
 

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -394,6 +394,54 @@ func _notification(what: int) -> void:
 						collection.remove_at(command_index)
 						collection.insert(command_index, branch)
 
+func _get(property: StringName):
+	match property:
+		"advanced/name":
+			return ""
+		"debug/position":
+			return position
+		"debug/index":
+			return index
+		"debug/owner":
+			return get_command_owner()
+		"debug/main_collection":
+			return get_main_collection()
+		_:
+			return
+
+func _get_property_list() -> Array[Dictionary]:
+	var p:Array[Dictionary] = []
+	p.append(
+		{
+			"name":"advanced/name",
+			"type":TYPE_STRING,
+			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+			"hint":PROPERTY_HINT_PLACEHOLDER_TEXT,
+			"hint_string":command_name,
+		})
+	if OS.is_stdout_verbose():
+		p.append({
+				"name":"debug/position",
+				"type":TYPE_INT,
+				"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+		})
+		p.append({
+			"name":"debug/index",
+			"type":TYPE_INT,
+			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY
+		})
+		p.append({
+			"name":"debug/owner",
+			"type":TYPE_OBJECT,
+			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+		})
+		p.append({
+			"name":"debug/main_collection",
+			"type":TYPE_OBJECT,
+			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+		})
+	return p
+
 ## Changes a variable of the target node.
 func _add_variable(varname: String, vartype, varvalue, target_node: Node):
 	if varname in target_node:

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -134,7 +134,7 @@ var command_category:StringName:
 
 ## [CommandBlock] item assigned by editor.
 ## [br]This reference is assigned by Block Editor.
-var editor_block:TreeItem
+var editor_block:Object
 
 ## Layout data used by editor. This data is saved in editor
 ## and is not shared between projects.

--- a/core/command_record.gd
+++ b/core/command_record.gd
@@ -32,6 +32,7 @@ var _updating:bool = false
 static func get_record() -> Object:
 	if not Engine.has_meta("CommandRecord"): 
 		return null
+	
 	return (Engine.get_meta("CommandRecord", null) as WeakRef).get_ref()
 
 ## Add a command to record.
@@ -193,7 +194,6 @@ func _register_default_commands() -> void:
 
 func _init() -> void:
 	if is_instance_valid(get_record()):
-		push_error("A CommandRecord already exist!")
 		return
 	
 	_updating = true

--- a/core/command_record.gd
+++ b/core/command_record.gd
@@ -29,7 +29,7 @@ var _paths:Dictionary = {}
 var _updating:bool = false
 
 ## Get the command record "singleton".
-static func get_record() -> Object:
+static func get_record():
 	if not Engine.has_meta("CommandRecord"): 
 		return null
 	

--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -2,7 +2,7 @@
 extends EditorPlugin
 
 const Blockflow = preload("res://addons/blockflow/blockflow.gd")
-const BlockEditor = preload("res://addons/blockflow/editor/views/editor_view.gd")
+const BlockEditor = preload("res://addons/blockflow/editor/views/in_editor_view.gd")
 const InspectorTools = preload("res://addons/blockflow/editor/inspector/inspector_tools.gd")
 const CollectionInspector = preload("res://addons/blockflow/editor/inspector/collection_inspector.gd")
 const CommandInspector = preload("res://addons/blockflow/editor/inspector/command_inspector.gd")
@@ -68,8 +68,7 @@ func _edit(object: Object) -> void:
 	if self_called_to_edit:
 		return
 	
-	var editor_undoredo := get_undo_redo()
-	block_editor.undo_redo = editor_undoredo.get_history_undo_redo(editor_undoredo.get_object_history_id(object))
+	block_editor.editor_undo_redo = get_undo_redo()
 	block_editor.edit(object)
 	last_edited_object = object
 
@@ -175,7 +174,7 @@ func _init() -> void:
 	
 	debugger = BlockflowDebugger.new()
 	
-	command_record = Blockflow.CommandRecord.get_record()
+	command_record = Blockflow.CommandRecord.new().get_record()
 	project_settings_changed.connect(command_record.reload_from_project_settings)
 	
 	# Add the plugin to the list when we're created as soon as possible.

--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -2,14 +2,17 @@
 extends EditorPlugin
 
 const Blockflow = preload("res://addons/blockflow/blockflow.gd")
-const BlockEditor = preload("res://addons/blockflow/editor/editor.gd")
+const BlockEditor = preload("res://addons/blockflow/editor/views/editor_view.gd")
 const InspectorTools = preload("res://addons/blockflow/editor/inspector/inspector_tools.gd")
+const CollectionInspector = preload("res://addons/blockflow/editor/inspector/collection_inspector.gd")
 const CommandInspector = preload("res://addons/blockflow/editor/inspector/command_inspector.gd")
 const CommandCallInspector = preload("res://addons/blockflow/editor/inspector/call_inspector.gd")
 const BlockflowDebugger = preload("res://addons/blockflow/debugger/blockflow_debugger.gd")
 
 const Constants = preload("res://addons/blockflow/core/constants.gd")
 const EditorConstants = preload("res://addons/blockflow/editor/constants.gd")
+
+const Utils = preload("res://addons/blockflow/core/utils.gd")
 
 
 var block_editor:BlockEditor
@@ -21,6 +24,7 @@ var last_handled_object:Object
 var node_selector:InspectorTools.NodeSelector
 var method_selector:InspectorTools.MethodSelector
 
+var collection_inspector:CollectionInspector
 var command_inspector:CommandInspector
 var command_call_inspector:CommandCallInspector
 
@@ -32,27 +36,22 @@ var theme:Theme = load(EditorConstants.DEFAULT_THEME_PATH) as Theme
 
 var command_record:Blockflow.CommandRecord
 
-func toast(message:String, severity:int = 0, tooltip:String = ""):
-	if not is_inside_tree():
-		return
-	if not is_instance_valid(editor_toaster):
-		return
-	
-	editor_toaster.call("_popup_str", message, severity, tooltip)
+var self_called_to_edit:bool = false
 
 func _enter_tree():
 	_define_toaster()
-	block_editor.toast_callback = toast
+	
+	add_inspector_plugin(collection_inspector)
+	add_inspector_plugin(command_inspector)
+	add_inspector_plugin(command_call_inspector)
+	add_debugger_plugin(debugger)
 	
 	get_editor_interface().get_editor_main_screen().add_child(block_editor)
 	get_editor_interface().get_base_control().add_child(node_selector)
 	get_editor_interface().get_base_control().add_child(method_selector)
 	_make_visible(false)
 	
-	add_inspector_plugin(command_inspector)
-	add_inspector_plugin(command_call_inspector)
-	
-	add_debugger_plugin(debugger)
+	_setup_theme()
 
 
 func _handles(object: Object) -> bool:
@@ -66,7 +65,11 @@ func _handles(object: Object) -> bool:
 
 
 func _edit(object: Object) -> void:
-	block_editor.editor_undoredo = get_undo_redo()
+	if self_called_to_edit:
+		return
+	
+	var editor_undoredo := get_undo_redo()
+	block_editor.undo_redo = editor_undoredo.get_history_undo_redo(editor_undoredo.get_object_history_id(object))
 	block_editor.edit(object)
 	last_edited_object = object
 
@@ -90,7 +93,7 @@ func _save_external_data() -> void:
 	queue_save_layout()
 
 func _get_window_layout(configuration: ConfigFile) -> void:
-	block_editor.save_layout()
+	pass
 
 func _define_toaster() -> void:
 	var dummy = Control.new()
@@ -105,12 +108,35 @@ func _define_toaster() -> void:
 
 	remove_control_from_bottom_panel(dummy)
 	dummy.queue_free()
+	Engine.set_meta(&"editor_toaster", editor_toaster)
+
+
+func _setup_theme() -> void:
+	theme = theme.duplicate() as Theme
+	var editor_theme:Theme = EditorInterface.get_editor_theme()
+	theme.set_stylebox("panel", "PanelContainer", StyleBoxEmpty.new())
+	theme.set_stylebox("panel", "ScrollContainer", editor_theme.get_stylebox("panel", "Tree"))
+	
+	theme.set_constant("separation", "BoxContainer", 0)
+	theme.set_constant("separation", "VBoxContainer", 0)
+	theme.set_constant("separation", "HBoxContainer", 0)
+	
+	theme.set_constant("separation", "SplitContainer", 4)
+	theme.set_constant("minimum_grab_thickness", "SplitContainer", 4)
+	
+	theme.set_stylebox("panel", "BlockEditor", editor_theme.get_stylebox("PanelForeground", "EditorStyles"))
+	
+	
+	block_editor.theme = theme
+	block_editor.queue_redraw()
+
 
 func _exit_tree():
 	queue_save_layout()
 	block_editor.queue_free()
 	
 	
+	remove_inspector_plugin(collection_inspector)
 	remove_inspector_plugin(command_inspector)
 	remove_inspector_plugin(command_call_inspector)
 	command_inspector = null
@@ -119,12 +145,18 @@ func _exit_tree():
 	remove_debugger_plugin(debugger)
 
 
+func _block_editor_command_selected(command) -> void:
+	self_called_to_edit = true
+	EditorInterface.edit_resource(command)
+	self_called_to_edit = false
+
 func _init() -> void:
 	block_editor = BlockEditor.new()
-	block_editor.edit_callback = Callable(get_editor_interface(), "edit_resource")
 	block_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	block_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	block_editor.command_selected.connect(_block_editor_command_selected)
 	
+	collection_inspector = CollectionInspector.new()
 	command_inspector = CommandInspector.new()
 	
 	node_selector = InspectorTools.NodeSelector.new()

--- a/core/utils.gd
+++ b/core/utils.gd
@@ -180,3 +180,10 @@ static func get_default_value_for_type(type:Variant.Type):
 		_, TYPE_MAX:
 			push_error("get_default_value_for_type:: UNKNOW_TYPE %s"%type)
 	return value
+
+func toast(message:String, severity:int = 0, tooltip:String = "") -> void:
+	var toaster:Object = Engine.get_meta(&"editor_toaster", null)
+	if not is_instance_valid(toaster):
+		return
+	
+	toaster.call("_popup_str", message, severity, tooltip)

--- a/editor/README.md
+++ b/editor/README.md
@@ -29,7 +29,7 @@ This class implements the necessary tools to show and manipulate a single `Colle
 ### in_editor_view.gd
 Editor view made for **in editor** usage only.
 
-## in_runtime_editor_view.gd
+### in_runtime_editor_view.gd
 Editor view made for runtime usage. Its usage in editor is not recommended.
 
 ## shortcuts

--- a/editor/README.md
+++ b/editor/README.md
@@ -2,3 +2,73 @@
 Blockflow editor.
 
 The editor main purpose is to provide a tool to create and modify collections and commands to be used later in game through processors.
+
+It should be able to:
+- Load stuff:
+    - [ ] Load a `Timeline`(unimplemented).
+    - [ ] Load a `Collection`, including, but not limited to `Command` and `CommandCollection`. 
+    - [ ] It can use the `File` menu, using the `Open...` option, to load a `Collection` or `Timeline` (unimplemented).
+    - [ ] The attempted file to inspect in editor will be automatically handled by the plugin, then passed to the editor.
+- Edit stuff:
+    - [ ] Create, move and remove `Event`s in `Timeline`s (unimplemented).
+    - [ ] Create, move and remove `Commands` in any `Collection` type. (unimplemented) For now you can only do that for `Command`s in `CommandCollection`s.
+    - [ ] Edit, copy and paste a `Command` using the context-menu and its related shortcuts, which is open by default with a right-click in any `CommandBlock`.
+    - [ ] Create `Timeline`s (unimplemented).
+    - [ ] Create `Command`s (unimplemented).
+    - [ ] Create `CommandCollection`s. 
+    - [ ] It can use the `File` menu, using the `New...` option
+- [ ] Display a list of `Event`s for its usage (unimplemented).
+- [ ] Display a list of `Command` for its usage. It uses `CommandList` with `CommandRecord` data in order to achieve it.
+
+## views
+### editor_view.gd
+Editor view base class. 
+
+This class implements the necessary tools to show and manipulate a single `Collection` object.
+
+### in_editor_view.gd
+Editor view made for **in editor** usage only.
+
+## in_runtime_editor_view.gd
+Editor view made for runtime usage. Its usage in editor is not recommended.
+
+## shortcuts
+Shortcut related resources.
+
+## playground
+Is supposed to contain test scenarios to debug the editor.
+
+## inspector
+`EditorInspector` related classes.
+
+Most of these modify and expand the inspector view of each object handled by Blockflow.
+
+### inspector_tools.gd
+A collection of tools and nodes.
+
+## displayer
+Nodes which goal is to show the internal structure of blockflow objects, like the internal tree structure of a `Collection`.
+
+### fancy_displayer.gd
+`DisplayerFancy` type. It creates a fake and custom tree structure, using custom scenes.
+
+### simple_displayer.gd
+`DisplayerSimple` type. It creates the tree structure using custom `TreeItems` and `Tree` node. 
+
+**Untested since the implementation of fancy displayer!!!**
+
+## command_block
+Objects that are the visual representation of a `Command`, used by `Displayer` types.
+
+**Classes defined on its root are not tested since the implementation of fancy displayer!!!**
+
+### fancy_block
+Fancy visual representation of a command, used by `DisplayerFancy`.
+
+#### block.gd
+Node representation of a `Command`, composed by multiple `BlockCell` to define its sections.
+
+#### block_cell.gd
+Custom container used in `block.gd` to define a section. It can contain any arbitrary ammount of nodes to display any arbitrary ammount of data. 
+
+We recommend to use `Control` node types to display data, and `Container` types to maintain a consistent layout.

--- a/editor/command_block/fancy_block/block.gd
+++ b/editor/command_block/fancy_block/block.gd
@@ -162,6 +162,12 @@ func _get_rect_width() -> int:
 func _update_block() -> void:
 	name_node.text = command.command_name
 	icon_node.texture = command.command_icon
+	
+	if not command.block_name.is_empty():
+		name_node.text = command.block_name
+	
+	if command.block_icon:
+		icon_node.texture = command.block_icon
 
 
 func _show_item_popup(popup:PopupMenu) -> void:

--- a/editor/command_block/fancy_block/block.gd
+++ b/editor/command_block/fancy_block/block.gd
@@ -1,0 +1,176 @@
+@tool
+extends HBoxContainer
+
+const BlockCell = preload("res://addons/blockflow/editor/command_block/fancy_block/block_cell.gd")
+const CommandClass = preload("res://addons/blockflow/commands/command.gd")
+
+class BlockButton extends BaseButton:
+	# https://github.com/godotengine/godot/blob/6a13fdcae3662975c101213d47a1eb3a7db63cb3/scene/gui/button.cpp#L131
+	func _get_current_stylebox() -> StyleBox:
+		var stylebox:StyleBox
+		
+		match get_draw_mode():
+			DRAW_NORMAL:
+				stylebox = get_theme_stylebox("normal", "Button")
+			DRAW_HOVER_PRESSED:
+				stylebox = get_theme_stylebox("hover_pressed","Button")
+			DRAW_PRESSED:
+				stylebox = get_theme_stylebox("pressed","Button")
+			DRAW_HOVER:
+				stylebox = get_theme_stylebox("hover","Button")
+			DRAW_DISABLED:
+				stylebox = get_theme_stylebox("disabled","Button")
+		
+		return stylebox
+	
+	func _notification(what):
+		var sb := _get_current_stylebox()
+		match what:
+			NOTIFICATION_DRAW:
+				draw_style_box(sb, Rect2(Vector2(), size))
+				
+				if has_focus():
+					draw_style_box( get_theme_stylebox("focus", "Button"), Rect2(Vector2(), size) )
+	
+	func _init():
+		toggle_mode = true
+
+var debug:bool = false:
+	set(value):
+		debug = value
+		for child in get_children(true):
+			child.set("debug",value)
+
+var indent_level:int:
+	set(value):
+		indent_level = value
+		_button.custom_minimum_size.x = 16 * indent_level
+		queue_sort()
+
+var command:CommandClass = null:
+	set=set_command
+
+var layout:Dictionary
+
+var icon_node:TextureRect
+var name_node:Label
+
+var _button:BlockButton
+
+func create_cell() -> BlockCell:
+	var cell:BlockCell = BlockCell.new()
+	add_child(cell)
+	var _owner = owner
+	if not is_instance_valid(_owner):
+		_owner = self
+	cell.owner = _owner
+	return cell
+
+
+func set_command(value:CommandClass) -> void:
+	if not value:
+		name_node.text = "[Unknow]"
+		icon_node.texture = get_theme_icon("Unknow", "BlockflowIcons")
+		return
+	
+	command = value
+	
+	name_node.text = command.command_name
+	icon_node.texture = command.command_icon
+	
+	if command.get_command_owner() is CommandClass:
+		indent_level += 1
+
+func _notification(what):
+	match what:
+		NOTIFICATION_SORT_CHILDREN:
+			fit_child_in_rect(_button, Rect2(0, 0, size.x, size.y))
+		NOTIFICATION_CHILD_ORDER_CHANGED:
+			notify_property_list_changed()
+			update_configuration_warnings()
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := PackedStringArray()
+	for child in get_children():
+		var c = child as BlockCell
+		if not c:
+			warnings.append("Child '%s' is not CellBlock type. This may cause layout incongruences."%child.name)
+	return warnings
+
+func _set(property: StringName, value: Variant) -> bool:
+	if property == "advanced/debug":
+		debug = value
+		return true
+	
+	return false
+
+
+func _get(property: StringName) -> Variant:
+	if property == "advanced/debug":
+		return debug
+	
+	if property.begins_with("advanced/cells"):
+		var p := property.trim_prefix("advanced/cells/")
+		var child_idx:int = -1
+		if p.is_valid_int():
+			child_idx = p.to_int()
+		
+		if child_idx > -1 and child_idx <= get_child_count():
+			return get_child(child_idx)
+		
+	return null
+
+
+func _get_property_list() -> Array:
+	var p := []
+	
+	p.append({
+		"name":"advanced/debug",
+		"type":TYPE_BOOL,
+		"usage":PROPERTY_USAGE_EDITOR
+	})
+	
+	for child_idx in get_child_count(false):
+		p.append({
+			"name":"advanced/cells/"+str(child_idx),
+			"type":TYPE_OBJECT,
+			"usage":PROPERTY_USAGE_EDITOR|PROPERTY_USAGE_READ_ONLY,
+			"hint":PROPERTY_HINT_NODE_TYPE
+			})
+	return p
+
+func _init():
+	name = "BlockNode"
+	size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_theme_constant_override("separation", 0)
+	
+	_button = BlockButton.new()
+	
+	var icon_cell := BlockCell.new()
+	icon_cell.name = &"IconCell"
+	icon_node = TextureRect.new()
+	icon_node.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT
+	icon_node.expand_mode = TextureRect.EXPAND_FIT_WIDTH
+	icon_node.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	icon_node.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	icon_node.custom_minimum_size = Vector2(16,16)
+	icon_cell.add_child(icon_node)
+	
+	var name_cell := BlockCell.new()
+	name_cell.name = &"NameCell"
+	name_node = Label.new()
+	name_node.text = "[Command Name]"
+	name_node.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	name_node.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	name_cell.add_child(name_node)
+	
+	add_child(_button, false, Node.INTERNAL_MODE_FRONT)
+	add_child(icon_cell, false, Node.INTERNAL_MODE_FRONT)
+	add_child(name_cell, false, Node.INTERNAL_MODE_FRONT)
+	
+	debug = false
+	command = null
+	
+	#get_window().theme.set_stylebox("panel", "PanelContainer", StyleBoxEmpty.new())
+	add_theme_stylebox_override("panel", StyleBoxEmpty.new())

--- a/editor/command_block/fancy_block/block.gd
+++ b/editor/command_block/fancy_block/block.gd
@@ -78,6 +78,7 @@ var _button:BlockButton
 var _sb_section:StyleBox
 
 func select() -> void:
+	if not is_inside_tree(): return
 	_button.button_pressed = true
 	_button.grab_focus()
 

--- a/editor/command_block/fancy_block/block_cell.gd
+++ b/editor/command_block/fancy_block/block_cell.gd
@@ -21,3 +21,5 @@ func _notification(what):
 
 func _init() -> void:
 	name = "BlockCell"
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	theme_type_variation = "BlockCell"

--- a/editor/command_block/fancy_block/block_cell.gd
+++ b/editor/command_block/fancy_block/block_cell.gd
@@ -23,3 +23,4 @@ func _init() -> void:
 	name = "BlockCell"
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 	theme_type_variation = "BlockCell"
+	show_behind_parent = true

--- a/editor/command_block/fancy_block/block_cell.gd
+++ b/editor/command_block/fancy_block/block_cell.gd
@@ -1,0 +1,23 @@
+@tool
+extends PanelContainer
+
+var debug_style:StyleBox
+
+var debug:bool = false:
+	set(value):
+		debug = value
+		var i := randi_range(0, 15)
+		debug_style = get_theme_stylebox("sub_inspector_bg"+str(i), "Editor")
+		queue_redraw()
+
+func _get_minimum_size() -> Vector2:
+	return Vector2(16, 16)
+
+func _notification(what):
+	match what:
+		NOTIFICATION_DRAW:
+			if debug:
+				draw_style_box(debug_style, Rect2(Vector2(), size))
+
+func _init() -> void:
+	name = "BlockCell"

--- a/editor/command_list.gd
+++ b/editor/command_list.gd
@@ -168,10 +168,11 @@ func _notification(what: int) -> void:
 			return
 		
 		NOTIFICATION_READY:
-			var command_record:CommandRecord = CommandRecord.get_record()
+			var command_record:CommandRecord = CommandRecord.new().get_record()
 			command_record.command_list_changed.connect(build_command_list)
 			build_command_list()
 
+var editor:Node
 func _init() -> void:
 	size_flags_vertical = Control.SIZE_EXPAND_FILL
 	custom_minimum_size = Vector2(128, 64)

--- a/editor/command_list.gd
+++ b/editor/command_list.gd
@@ -180,4 +180,5 @@ func _init() -> void:
 	scroll_container = ScrollContainer.new()
 	scroll_container.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	scroll_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	add_child(scroll_container)

--- a/editor/constants.gd
+++ b/editor/constants.gd
@@ -7,6 +7,30 @@ enum {
 	NOTIFICATION_EDITOR_ENABLED = 9004,
 }
 
+enum ItemPopup {
+	NAME,
+	MOVE_UP, 
+	MOVE_DOWN, 
+	DUPLICATE,
+	REMOVE,
+	COPY,
+	PASTE,
+	CREATE_TEMPLATE,
+	}
+
+enum DropSection {
+	NO_ITEM = -100, 
+	ABOVE_ITEM = -1,
+	ON_ITEM,
+	BELOW_ITEM,
+	}
+
+enum Section {
+	LEFT,
+	CENTER,
+	RIGHT
+}
+
 const DEFAULT_LAYOUT_FILE =\
 &"res://.godot/editor/block_editor_cache.cfg"
 
@@ -19,3 +43,4 @@ const SHORTCUT_DUPLICATE = preload("res://addons/blockflow/editor/shortcuts/dupl
 const SHORTCUT_DELETE = preload("res://addons/blockflow/editor/shortcuts/delete.tres")
 const SHORTCUT_COPY = preload("res://addons/blockflow/editor/shortcuts/copy.tres")
 const SHORTCUT_PASTE = preload("res://addons/blockflow/editor/shortcuts/paste.tres")
+const SHORTCUT_OPEN_MENU = preload("res://addons/blockflow/editor/shortcuts/open_menu.tres")

--- a/editor/displayer/fancy_displayer.gd
+++ b/editor/displayer/fancy_displayer.gd
@@ -21,7 +21,6 @@ var _vb:VBoxContainer
 
 func clear() -> void:
 	if is_instance_valid(_root):
-		_sc.remove_child(_root)
 		_root.queue_free()
 	_create_root()
 
@@ -63,7 +62,7 @@ func _display_command_collection(command_collection:CCollectionClass) -> void:
 	for block in blocks:
 		_root.add_child(block)
 	
-	emit_signal.bind("display_finished").call_deferred()
+	display_finished.emit.call_deferred()
 
 func _display_collection(collection:CollectionClass) -> void:
 	_create_root()

--- a/editor/displayer/fancy_displayer.gd
+++ b/editor/displayer/fancy_displayer.gd
@@ -1,0 +1,79 @@
+@tool
+extends PanelContainer
+
+const CollectionClass = preload("res://addons/blockflow/collection.gd")
+const CommandClass = preload("res://addons/blockflow/commands/command.gd")
+const CCollectionClass = preload("res://addons/blockflow/command_collection.gd")
+const Block = preload("res://addons/blockflow/editor/command_block/fancy_block/block.gd")
+
+var displayed_commands:Array
+var current_collection:CollectionClass
+
+var _group:ButtonGroup
+var _root:VBoxContainer
+var _sc:ScrollContainer
+var _vb:VBoxContainer
+
+func _display(object:Object) -> void:
+	if object is CommandClass:
+		_display_command(object)
+	
+	if object is CCollectionClass:
+		_display_command_collection(object)
+	
+	if object is CollectionClass:
+		_display_collection(object)
+
+
+func _display_command(command:CommandClass) -> void:
+	var blocks:Array[Node] = []
+	
+	current_collection = command
+	_build_fake_tree(current_collection, blocks)
+	
+	for block in blocks:
+		_root.add_child(block)
+
+func _display_command_collection(command_collection:CCollectionClass) -> void:
+	var blocks:Array[Node] = []
+	
+	current_collection = command_collection
+	_group = ButtonGroup.new()
+	_build_fake_tree(current_collection, blocks,0)
+	
+	for block in blocks:
+		_root.add_child(block)
+
+func _display_collection(collection:CollectionClass) -> void:
+	pass
+
+func _build_fake_tree(curr_c, blocks, itr_lvl=0):
+	if curr_c is CommandClass:
+		if curr_c.get_command_owner() is CommandClass:
+			itr_lvl += 1
+	
+	for command in curr_c:
+		var block := Block.new()
+		block._button.button_group = _group
+		block.indent_level = itr_lvl
+		block.command = command
+		blocks.append(block)
+		
+		if not command.is_empty():
+			_build_fake_tree(command, blocks, itr_lvl)
+
+func _init():
+	_vb = VBoxContainer.new()
+	_vb.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_vb.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	add_child(_vb)
+	
+	_sc = ScrollContainer.new()
+	_sc.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_sc.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_vb.add_child(_sc)
+	
+	_root = VBoxContainer.new()
+	_root.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_root.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_sc.add_child(_root)

--- a/editor/displayer/fancy_displayer.gd
+++ b/editor/displayer/fancy_displayer.gd
@@ -22,6 +22,7 @@ var _vb:VBoxContainer
 func clear() -> void:
 	if is_instance_valid(_root):
 		_root.queue_free()
+		_sc.remove_child(_root)
 	_create_root()
 
 func display(object:Object) -> void:

--- a/editor/displayer/simple_displayer.gd
+++ b/editor/displayer/simple_displayer.gd
@@ -1,0 +1,123 @@
+@tool
+extends Tree
+
+const Blockflow = preload("res://addons/blockflow/blockflow.gd")
+const CollectionClass = preload("res://addons/blockflow/command_collection.gd")
+
+const CommandBlock = preload("res://addons/blockflow/editor/command_block/block.gd")
+const RootBlock = preload("res://addons/blockflow/editor/command_block/root.gd")
+
+const FALLBACK_ICON = preload("res://addons/blockflow/icons/false.svg")
+const BOOKMARK_ICON = preload("res://addons/blockflow/icons/bookmark.svg")
+const STOP_ICON = preload("res://addons/blockflow/icons/stop.svg")
+const CONTINUE_ICON = preload("res://addons/blockflow/icons/play.svg")
+
+var last_selected_command:Blockflow.CommandClass
+
+var _current_collection:CollectionClass
+
+var root:RootBlock
+var displayed_commands:Array = []
+
+func build_tree(object:Object) -> void:
+	var collection:CollectionClass
+	collection = object as CollectionClass
+	
+	_current_collection = collection
+	_reload()
+
+
+func _reload() -> void:
+	clear()
+	
+	displayed_commands = []
+	
+	if not _current_collection:
+		last_selected_command = null
+		return
+	
+	var min_width:int = 24 + get_theme_constant("icon_min_size", "BlockEditor")
+	set_column_custom_minimum_width(CommandBlock.ColumnPosition.NAME_COLUMN, min_width*columns)
+	set_column_custom_minimum_width(CommandBlock.ColumnPosition.INDEX_COLUMN, 42)
+	
+	var r:TreeItem = create_item()
+	r.set_script(RootBlock)
+	root = r as RootBlock
+	root.collection = _current_collection
+	
+	var commands:Array = _current_collection.collection
+	var subcommand:Array = []
+	
+	for command in _current_collection:
+		_add_command(command, root)
+	
+	root.call_recursive("update")
+	if last_selected_command and is_instance_valid(last_selected_command.editor_block):
+		last_selected_command.editor_block.select(0)
+		ensure_cursor_is_visible()
+	else:
+		last_selected_command = null
+	
+
+func _add_command(command:Blockflow.CommandClass, under_block:CommandBlock) -> void:
+	if command in displayed_commands:
+		assert(false)
+		return
+	if not command:
+		assert(false)
+		return
+	var itm:TreeItem = create_item(under_block)
+	itm.set_script(CommandBlock)
+	var block:CommandBlock = itm as CommandBlock
+	block.command = command
+	command.editor_block = block
+	
+	displayed_commands.append(command)
+	for subcommand in command:
+		_add_command(subcommand, block)
+
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.double_click:
+		if get_selected() == root:
+			assert(false, "Editing through double click is not implemented")
+			accept_event()
+
+
+func _on_item_edited() -> void:
+	if get_selected() == root:
+		_current_collection.resource_name = root.get_text(0)
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_ENTER_TREE, NOTIFICATION_THEME_CHANGED:
+			set_column_expand(CommandBlock.ColumnPosition.NAME_COLUMN, false)
+			set_column_expand(CommandBlock.ColumnPosition.HINT_COLUMN, true)
+			set_column_expand(CommandBlock.ColumnPosition.BUTTON_COLUMN, false)
+			set_column_expand(CommandBlock.ColumnPosition.INDEX_COLUMN, false)
+			
+			set_column_clip_content(
+				CommandBlock.ColumnPosition.NAME_COLUMN,
+				false
+			)
+			
+			set_column_clip_content(
+				CommandBlock.ColumnPosition.HINT_COLUMN,
+				true
+			)
+			
+			set_column_clip_content(
+				CommandBlock.ColumnPosition.INDEX_COLUMN,
+				false
+			)
+
+
+func _init() -> void:
+	# Allows multiple column stuff without manually change
+	columns = CommandBlock.ColumnPosition.size()
+	allow_rmb_select = true
+	select_mode = SELECT_ROW
+	scroll_horizontal_enabled = false
+	
+	item_edited.connect(_on_item_edited)
+

--- a/editor/inspector/collection_inspector.gd
+++ b/editor/inspector/collection_inspector.gd
@@ -1,0 +1,31 @@
+@tool
+extends "res://addons/blockflow/editor/inspector/inspector_tools.gd"
+
+func _can_handle(object: Object) -> bool:
+	return object is CollectionClass
+
+func _parse_end(object: Object) -> void:
+	var collection := object as CollectionClass
+	if collection.is_empty():
+		return
+	var sc := ScrollContainer.new()
+	sc.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sc.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	sc.custom_minimum_size = Vector2(0, 254)
+	
+	var displayer := Tree.new()
+	sc.add_child(displayer)
+	displayer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	displayer.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	displayer.custom_minimum_size = Vector2(0, 254)
+	
+	var root := displayer.create_item()
+	root.set_text(0,"Internal collection")
+	
+	for child in collection:
+		var item := displayer.create_item(root)
+		item.set_text(0, str(child.get("command_name")))
+	
+	root.collapsed = true
+	
+	add_custom_control(sc)

--- a/editor/shortcuts/open_menu.tres
+++ b/editor/shortcuts/open_menu.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Shortcut" load_steps=2 format=3 uid="uid://br6vdg8wq21eq"]
+
+[sub_resource type="InputEventMouseButton" id="InputEventMouseButton_pjkbj"]
+button_mask = 2
+button_index = 2
+
+[resource]
+events = [SubResource("InputEventMouseButton_pjkbj")]

--- a/editor/theme.tres
+++ b/editor/theme.tres
@@ -4,7 +4,16 @@
 [ext_resource type="Texture2D" uid="uid://bmpioqcojkwso" path="res://addons/blockflow/icons/branch.svg" id="1_wf2ny"]
 [ext_resource type="Texture2D" uid="uid://bjpgrlbxe2frx" path="res://addons/blockflow/icons/plugin_icon_flat.svg" id="2_bbrvm"]
 
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_j0yct"]
+
 [resource]
+Block/base_type = &"HBoxContainer"
+Block/constants/indent_size = 16
+Block/constants/rect_width = 4
+Block/constants/separation = 0
+BlockCell/base_type = &"PanelContainer"
+BlockCell/styles/panel = SubResource("StyleBoxEmpty_j0yct")
+BlockEditor/base_type = &"PanelContainer"
 BlockEditor/constants/icon_min_size = 32
 Category/icons/Flow = ExtResource("1_wf2ny")
 PluginIcons/icons/plugin_icon = ExtResource("1_jlt6l")

--- a/editor/views/editor_view.gd
+++ b/editor/views/editor_view.gd
@@ -1,0 +1,585 @@
+@tool
+extends PanelContainer
+
+const Constants = preload("res://addons/blockflow/editor/constants.gd")
+
+const CommandList = preload("res://addons/blockflow/editor/command_list.gd")
+
+const CollectionClass = preload("res://addons/blockflow/collection.gd")
+const CommandClass = preload("res://addons/blockflow/commands/command.gd")
+const CCollectionClass = preload("res://addons/blockflow/command_collection.gd")
+const CommandRecord = preload("res://addons/blockflow/core/command_record.gd")
+
+const DisplayerFancy = preload("res://addons/blockflow/editor/displayer/fancy_displayer.gd")
+const DisplayerSimple = preload("res://addons/blockflow/editor/displayer/simple_displayer.gd")
+
+enum ToolbarFileMenu {
+	NEW,
+	OPEN,
+	CLOSE,
+	RECENT,
+}
+
+static var editors := {}
+static var command_clipboard:CommandClass
+
+var edited_object:Object:
+	set=edit
+
+var undo_redo:UndoRedo
+var history:Dictionary
+var last_selected_command:CommandClass
+var command_record:CommandRecord
+
+#region Editor Nodes
+var displayer:Node
+
+var toolbar:MenuBar
+var menu_file:PopupMenu
+var menu_recent:PopupMenu
+
+var command_popup:PopupMenu
+
+var command_list:CommandList
+
+var file_dialog:Node
+#endregion
+
+var selected_commands:Array
+
+#region EDITOR PRIVATE DATA
+# Current edited timeline
+var _current_timeline
+# Current edited event
+var _current_event
+# Current edited collection
+var _current_collection:CollectionClass
+# Current edited command
+var _current_command:CommandClass
+#endregion
+
+
+func edit(object:Object) -> void:
+	edited_object = null
+	#if object is TimelineClass:
+		#left_section_show()
+		#_edit_timeline()
+	
+	if object is CommandClass:
+		edited_object = object
+		left_section_hide()
+		_edit_command()
+		return
+	
+	if object is CCollectionClass:
+		edited_object = object
+		_edit_command_collection()
+		return
+	
+	if object is CollectionClass:
+		edited_object = object
+		_edit_collection()
+		return
+
+func enable() -> void:
+	propagate_call("set", ["editor", self])
+	propagate_notification(Constants.NOTIFICATION_EDITOR_ENABLED)
+
+func disable() -> void:
+	propagate_notification(Constants.NOTIFICATION_EDITOR_DISABLED)
+
+func close() -> void:
+	pass
+
+func add_command(command:CommandClass, at_position:int = -1, to_collection:CollectionClass = null) -> void:
+	if not _current_collection: return
+	if not command: return
+	if not to_collection:
+		to_collection = _current_collection
+	
+	var action_name:String = "Add command '%s'" % [command.command_name]
+	last_selected_command = command
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	if at_position < 0:
+		undo_redo.add_do_method(to_collection.add.bind(command))
+	else:
+		undo_redo.add_do_method(to_collection.insert.bind(command, at_position))
+	
+	undo_redo.add_undo_method(to_collection.erase.bind(command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
+
+
+func move_command(command:CommandClass, to_position:int, from_collection:CollectionClass=null, to_collection:CollectionClass=null) -> void:
+	if not _current_collection: return
+	if not command: return
+	
+	if not from_collection:
+		from_collection = command.get_command_owner()
+	if not to_collection:
+		to_collection = command.get_command_owner()
+	
+	if not from_collection:
+		# It comes from nowhere, maybe we're adding instead of moving?
+		add_command(command, to_position, to_collection)
+		return
+
+	if to_collection == command:
+		push_error("Can't move into self!")
+		return
+
+	var weak_owner = to_collection.weak_owner
+	if weak_owner:
+		weak_owner = weak_owner.get_ref()
+	while weak_owner:
+		if weak_owner is WeakRef:
+			weak_owner = weak_owner.get_ref()
+		if weak_owner == command:
+			push_error("Found self in parents, can't move into self!")
+			return
+		weak_owner = weak_owner.weak_owner
+
+	var from_position:int = from_collection.get_command_position(command)
+	var action_name:String = "Move command '%s'" % [command.command_name]
+	
+	disable()
+	undo_redo.create_action(action_name)
+	if from_collection == to_collection:
+		undo_redo.add_do_method(from_collection.move.bind(command, to_position))
+		undo_redo.add_undo_method(from_collection.move.bind(command, from_position))
+	else:
+		undo_redo.add_do_method(from_collection.erase.bind(command))
+		undo_redo.add_undo_method(from_collection.insert.bind(command, from_position))
+		undo_redo.add_do_method(to_collection.insert.bind(command, to_position))
+		undo_redo.add_undo_method(to_collection.erase.bind(command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
+
+func duplicate_command(command:CommandClass, to_index:int) -> void:
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("!command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("!command_collection")
+		return
+	
+	var action_name:String = "Duplicate command '%s'" % [command.command_name]
+	var duplicated_command = command.get_duplicated()
+	last_selected_command = duplicated_command
+	var idx = to_index if to_index > -1 else command_collection.size()
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	undo_redo.add_do_method(command_collection.insert.bind(duplicated_command, to_index))
+	undo_redo.add_undo_method(command_collection.erase.bind(duplicated_command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
+
+
+func remove_command(command:CommandClass) -> void:
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("not command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("not command_collection")
+		return
+	
+	var action_name:String = "Remove command '%s'" % [command.command_name]
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	undo_redo.add_do_method(command_collection.remove.bind(command.index))
+	undo_redo.add_undo_method(command_collection.insert.bind(command, command.index))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
+
+
+func copy_command(command:CommandClass) -> void:
+	command_clipboard = command
+
+
+func toolbar_update_menu_recent() -> void:
+	menu_recent.clear()
+	if history.is_empty():
+		menu_recent.add_item("No recent resources...")
+		menu_recent.set_item_disabled(0, true)
+		return
+	
+	var keys := history.keys()
+	for i in keys.size():
+		var history_key:String = keys[i]
+		menu_recent.add_item(history_key)
+		menu_recent.set_item_tooltip(i, history[history_key])
+		
+		if edited_object and history[history_key] == edited_object.resource_path:
+			menu_recent.set_item_text(i, history_key + " (Current)")
+			menu_recent.set_item_disabled(i, true)
+
+func left_section_hide() -> void:
+	pass
+
+func left_section_show() -> void:
+	pass
+
+
+func request_new_command_collection() -> void:
+	file_dialog.current_dir = ""
+	file_dialog.file_mode = EditorFileDialog.FILE_MODE_SAVE_FILE
+	file_dialog.filters = ["*.tres, *.res ; Resource file"]
+	file_dialog.title = "New CommandCollection"
+	file_dialog.popup_centered_ratio(0.5)
+
+
+func request_open_command_collection() -> void:
+	file_dialog.current_dir = ""
+	file_dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_FILE
+	file_dialog.filters = ["*.tres, *.res ; Resource file"]
+	file_dialog.title = "Load Collection"
+	file_dialog.popup_centered_ratio(0.5)
+
+func _edit_timeline() -> void:
+	#event_displayer.display(object.events)
+	#displayer.display(object)
+	pass
+
+
+func _edit_command_collection() -> void:
+	var object:CCollectionClass = edited_object as CCollectionClass
+	displayer.display(object)
+	
+	if not object:
+		_disconnect_current_collection_signals()
+		disable()
+		return
+	
+	if object != _current_collection:
+		_disconnect_current_collection_signals()
+		_current_collection = object
+		_connect_current_collection_signals()
+	
+	enable()
+
+
+func _edit_command() -> void:
+	var object:CommandClass = edited_object as CommandClass
+	displayer.display(object)
+
+
+func _edit_collection() -> void:
+	var object:CollectionClass = edited_object as CollectionClass
+	displayer.display(object)
+
+
+func _connect_current_collection_signals() -> void:
+	if not _current_collection:
+		return
+	
+	if _current_collection.collection_changed.is_connected(_edited_object_changed):
+		return
+	
+	_current_collection.collection_changed.connect(_edited_object_changed.bind(_current_collection))
+
+func _disconnect_current_collection_signals() -> void:
+	if not _current_collection:
+		return
+	
+	if not _current_collection.collection_changed.is_connected(_edited_object_changed):
+		return
+	
+	_current_collection.collection_changed.disconnect(_edited_object_changed)
+
+
+# Resource.changed signal was emited
+func _edited_object_changed(object:Object) -> void:
+	if object == _current_collection:
+		displayer.display(object)
+
+
+func _command_popup_id_pressed(id:int) -> void:
+	var command:CommandClass = _current_command
+	var command_idx:int = command.index
+	match id:
+		Constants.ItemPopup.MOVE_UP:
+			move_command(command, max(0, command_idx - 1))
+			
+		Constants.ItemPopup.MOVE_DOWN:
+			move_command(command, command_idx + 1)
+
+		Constants.ItemPopup.DUPLICATE:
+			duplicate_command(command, command_idx + 1)
+			
+		Constants.ItemPopup.REMOVE:
+			remove_command(command)
+		
+		Constants.ItemPopup.COPY:
+			copy_command(command)
+		
+		Constants.ItemPopup.PASTE:
+			add_command(command_clipboard.get_duplicated(), command_idx + 1, command.get_command_owner())
+
+
+func _toolbar_menu_file_id_pressed(id:int) -> void:
+	match id:
+		ToolbarFileMenu.NEW:
+			request_new_command_collection()
+		ToolbarFileMenu.OPEN:
+			request_open_command_collection()
+		ToolbarFileMenu.CLOSE:
+			close()
+
+
+func _toolbar_menu_recent_item_selected(index:int) -> void:
+	pass
+
+
+func _command_list_button_pressed(command:CommandClass) -> void:
+	if not edited_object:
+		return
+	
+	var command_idx:int = -1
+	var new_command:CommandClass = command.get_duplicated()
+	var in_collection = _current_collection
+	if last_selected_command:
+		if last_selected_command.can_hold_commands:
+			command_idx = -1
+			in_collection = last_selected_command
+		else:
+			command_idx = last_selected_command.index + 1
+			in_collection = last_selected_command.get_command_owner()
+			
+	last_selected_command = new_command
+	add_command(new_command, command_idx, in_collection)
+
+
+func _displayer_command_selected(command:CommandClass) -> void:
+	if Input.is_physical_key_pressed(KEY_CTRL):
+		if last_selected_command:
+			last_selected_command.editor_block.keep_selected = true
+			selected_commands.append(last_selected_command)
+	else:
+		for selected_command in selected_commands:
+			selected_command.editor_block.keep_selected = false
+		selected_commands.clear()
+	
+	_current_command = command
+	last_selected_command = command
+
+func _displayer_display_finished() -> void:
+	if not last_selected_command:
+		return
+	
+	if is_instance_valid(last_selected_command.editor_block):
+		last_selected_command.editor_block.select()
+
+
+func _displayer_can_drop_data(at_position: Vector2, data: Variant) -> bool:
+	if typeof(data) != TYPE_DICTIONARY:
+		return false
+	
+	var moved_command:CommandClass = data.get(&"resource", null) as CommandClass
+	if not moved_command:
+		return false
+	
+	return true
+
+
+func _displayer_drop_data(at_position: Vector2, data: Variant) -> void:
+	var drag_command:CommandClass = data.get(&"resource", null)
+	if not drag_command:
+		return
+	
+	move_command(drag_command, -1, null, _current_collection)
+
+
+func _file_dialog_file_selected(path:String) -> void:
+	var collection:CCollectionClass
+		
+	if file_dialog.file_mode == EditorFileDialog.FILE_MODE_SAVE_FILE:
+		collection = CCollectionClass.new()
+		collection.resource_name = path.get_file()
+		
+		var err:int = ResourceSaver.save(collection, path)
+		if err != 0:
+			push_error("Saving CommandCollection failed with Error '%s'(%s)" % [err, error_string(err)])
+			return
+		collection = load(path)
+	
+	var resource:Resource = load(path)
+	var condition:bool = resource is CollectionClass
+	if not resource or not condition:
+		push_error("CollectionEditor: '%s' is not a valid Collection" % path)
+		return
+	
+	edit(resource)
+
+
+func _shortcut_input(event: InputEvent) -> void:
+	var focus_owner:Control = get_viewport().gui_get_focus_owner()
+	if not is_instance_valid(focus_owner):
+		return
+	
+	if not (displayer.is_ancestor_of(focus_owner) or displayer == focus_owner):
+		return
+	
+	if not is_instance_valid(displayer.selected_item):
+		return
+	
+	var command:CommandClass = displayer.selected_item.command
+	if not command:
+		return
+	
+	var command_idx:int = command.index
+	
+	if Constants.SHORTCUT_MOVE_UP.matches_event(event) and event.is_released():
+		move_command(command, max(0, command_idx - 1))
+		accept_event()
+		return
+
+	if Constants.SHORTCUT_MOVE_DOWN.matches_event(event) and event.is_released():
+		move_command(command, command_idx + 1)
+		accept_event()
+		return
+
+	if Constants.SHORTCUT_DUPLICATE.matches_event(event) and event.is_released():
+		duplicate_command(command, command_idx + 1)
+		accept_event()
+		return
+	
+	if Constants.SHORTCUT_DELETE.matches_event(event) and event.is_released():
+		remove_command(command)
+		accept_event()
+		return
+	
+	if Constants.SHORTCUT_COPY.matches_event(event) and event.is_released():
+		copy_command(command)
+	
+	if Constants.SHORTCUT_PASTE.matches_event(event) and event.is_released():
+		if not command_clipboard:
+			return
+		
+		add_command(command_clipboard.get_duplicated(), command_idx + 1, command.get_command_owner())
+
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_READY:
+			if not edited_object:
+				disable()
+
+
+func _init() -> void:
+	name = "BlockflowEditor"
+	size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	size_flags_vertical = Control.SIZE_EXPAND_FILL
+	theme = load(Constants.DEFAULT_THEME_PATH) as Theme
+	
+	command_popup = PopupMenu.new()
+	command_popup.name = "ItemPopup"
+	command_popup.allow_search = false
+	command_popup.exclusive = false
+	command_popup.id_pressed.connect(_command_popup_id_pressed, CONNECT_DEFERRED)
+	add_child(command_popup)
+	
+	var vb := VBoxContainer.new()
+	vb.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vb.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	add_child(vb)
+	
+	toolbar = MenuBar.new()
+	toolbar.flat = true
+	vb.add_child(toolbar)
+	
+	menu_file = PopupMenu.new()
+	menu_file.allow_search = false
+	menu_file.id_pressed.connect(_toolbar_menu_file_id_pressed)
+	menu_file.add_item("New...", ToolbarFileMenu.NEW)
+	menu_file.add_item("Open...", ToolbarFileMenu.OPEN)
+	
+	menu_recent = PopupMenu.new()
+	menu_recent.name = "HistoryNode"
+	menu_recent.index_pressed.connect(_toolbar_menu_recent_item_selected)
+	menu_file.add_child(menu_recent)
+	menu_file.add_submenu_item("Open Recent", "HistoryNode", ToolbarFileMenu.RECENT)
+	toolbar_update_menu_recent()
+	
+	menu_file.add_separator()
+	menu_file.add_item("Close current collection", ToolbarFileMenu.CLOSE)
+	menu_file.set_item_disabled(menu_file.get_item_index(ToolbarFileMenu.CLOSE), true)
+	toolbar.add_child(menu_file)
+	
+	toolbar.set_menu_title(0, "File")
+	
+	var hb := HBoxContainer.new()
+	hb.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	vb.add_child(hb)
+	
+	var split_left := SplitContainer.new()
+	split_left.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	split_left.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	hb.add_child(split_left)
+	
+	var section_left := PanelContainer.new()
+	section_left.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	section_left.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	section_left.size_flags_stretch_ratio = 0.15
+	var split_center := SplitContainer.new()
+	split_center.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	split_center.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	split_left.add_child(section_left)
+	split_left.add_child(split_center)
+	
+	var section_center := PanelContainer.new()
+	section_center.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	section_center.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var section_right := PanelContainer.new()
+	split_center.add_child(section_center)
+	split_center.add_child(section_right)
+	
+	command_list = CommandList.new()
+	command_list.name = "CommandList"
+	command_list.command_button_pressed_callback = _command_list_button_pressed
+	section_right.add_child(command_list)
+	
+	command_record = CommandRecord.new().get_record()
+	
+	editors[&"unknow_editors"] = editors.get(&"unknow_editors", [])
+	editors[&"unknow_editors"].append(self)
+	
+	displayer = DisplayerFancy.new()
+	displayer.command_selected.connect(_displayer_command_selected)
+	displayer.display_finished.connect(_displayer_display_finished)
+	displayer.set_drag_forwarding(Callable(), _displayer_can_drop_data, _displayer_drop_data)
+	section_center.add_child(displayer)
+	
+	file_dialog = FileDialog.new()
+	file_dialog.file_selected.connect(_file_dialog_file_selected)
+	add_child(file_dialog)

--- a/editor/views/editor_view.gd
+++ b/editor/views/editor_view.gd
@@ -45,6 +45,8 @@ var command_popup:PopupMenu
 var command_list:CommandList
 
 var file_dialog:Node
+
+var section_left:PanelContainer
 #endregion
 
 var selected_commands:Array
@@ -83,6 +85,9 @@ func edit(object:Object) -> void:
 		return
 
 func enable() -> void:
+	if not _current_timeline:
+		left_section_hide()
+	
 	propagate_call("set", ["editor", self])
 	propagate_notification(Constants.NOTIFICATION_EDITOR_ENABLED)
 
@@ -246,10 +251,10 @@ func toolbar_update_menu_recent() -> void:
 			menu_recent.set_item_disabled(i, true)
 
 func left_section_hide() -> void:
-	pass
+	section_left.visible = false
 
 func left_section_show() -> void:
-	pass
+	section_left.visible = true
 
 
 func request_new_command_collection() -> void:
@@ -495,6 +500,7 @@ func _notification(what: int) -> void:
 	match what:
 		NOTIFICATION_READY:
 			if not edited_object:
+				left_section_hide()
 				disable()
 
 
@@ -550,13 +556,13 @@ func _init() -> void:
 	split_left.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	hb.add_child(split_left)
 	
-	var section_left := PanelContainer.new()
-	section_left.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	section_left.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	section_left.size_flags_stretch_ratio = 0.15
+	section_left = PanelContainer.new()
+	#section_left.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	#section_left.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	#section_left.size_flags_stretch_ratio = 0.15
 	var split_center := SplitContainer.new()
-	split_center.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	split_center.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	#split_center.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	#split_center.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	split_left.add_child(section_left)
 	split_left.add_child(split_center)
 	

--- a/editor/views/editor_view.gd
+++ b/editor/views/editor_view.gd
@@ -28,7 +28,6 @@ static var command_clipboard:CommandClass
 var edited_object:Object:
 	set=edit
 
-var undo_redo:UndoRedo
 var history:Dictionary
 var last_selected_command:CommandClass
 var command_record:CommandRecord
@@ -95,138 +94,19 @@ func disable() -> void:
 	propagate_notification(Constants.NOTIFICATION_EDITOR_DISABLED)
 
 func close() -> void:
-	pass
+	assert("NOT_IMPLEMENTED")
 
 func add_command(command:CommandClass, at_position:int = -1, to_collection:CollectionClass = null) -> void:
-	if not _current_collection: return
-	if not command: return
-	if not to_collection:
-		to_collection = _current_collection
-	
-	var action_name:String = "Add command '%s'" % [command.command_name]
-	last_selected_command = command
-	
-	disable()
-	undo_redo.create_action(action_name)
-		
-	if at_position < 0:
-		undo_redo.add_do_method(to_collection.add.bind(command))
-	else:
-		undo_redo.add_do_method(to_collection.insert.bind(command, at_position))
-	
-	undo_redo.add_undo_method(to_collection.erase.bind(command))
-	
-	undo_redo.add_do_method(_current_collection.update)
-	undo_redo.add_undo_method(_current_collection.update)
-	
-	undo_redo.commit_action()
-	enable()
-
+	assert("NOT_IMPLEMENTED")
 
 func move_command(command:CommandClass, to_position:int, from_collection:CollectionClass=null, to_collection:CollectionClass=null) -> void:
-	if not _current_collection: return
-	if not command: return
-	
-	if not from_collection:
-		from_collection = command.get_command_owner()
-	if not to_collection:
-		to_collection = command.get_command_owner()
-	
-	if not from_collection:
-		# It comes from nowhere, maybe we're adding instead of moving?
-		add_command(command, to_position, to_collection)
-		return
-
-	if to_collection == command:
-		push_error("Can't move into self!")
-		return
-
-	var weak_owner = to_collection.weak_owner
-	if weak_owner:
-		weak_owner = weak_owner.get_ref()
-	while weak_owner:
-		if weak_owner is WeakRef:
-			weak_owner = weak_owner.get_ref()
-		if weak_owner == command:
-			push_error("Found self in parents, can't move into self!")
-			return
-		weak_owner = weak_owner.weak_owner
-
-	var from_position:int = from_collection.get_command_position(command)
-	var action_name:String = "Move command '%s'" % [command.command_name]
-	
-	disable()
-	undo_redo.create_action(action_name)
-	if from_collection == to_collection:
-		undo_redo.add_do_method(from_collection.move.bind(command, to_position))
-		undo_redo.add_undo_method(from_collection.move.bind(command, from_position))
-	else:
-		undo_redo.add_do_method(from_collection.erase.bind(command))
-		undo_redo.add_undo_method(from_collection.insert.bind(command, from_position))
-		undo_redo.add_do_method(to_collection.insert.bind(command, to_position))
-		undo_redo.add_undo_method(to_collection.erase.bind(command))
-	
-	undo_redo.add_do_method(_current_collection.update)
-	undo_redo.add_undo_method(_current_collection.update)
-	
-	undo_redo.commit_action()
-	enable()
+	assert("NOT_IMPLEMENTED")
 
 func duplicate_command(command:CommandClass, to_index:int) -> void:
-	if not _current_collection: return
-	if not command: return
-	var command_collection:CollectionClass
-	if not command.weak_owner:
-		push_error("!command.weak_owner")
-		return
-	command_collection = command.get_command_owner()
-	if not command_collection:
-		push_error("!command_collection")
-		return
-	
-	var action_name:String = "Duplicate command '%s'" % [command.command_name]
-	var duplicated_command = command.get_duplicated()
-	last_selected_command = duplicated_command
-	var idx = to_index if to_index > -1 else command_collection.size()
-	
-	disable()
-	undo_redo.create_action(action_name)
-		
-	undo_redo.add_do_method(command_collection.insert.bind(duplicated_command, to_index))
-	undo_redo.add_undo_method(command_collection.erase.bind(duplicated_command))
-	
-	undo_redo.add_do_method(_current_collection.update)
-	undo_redo.add_undo_method(_current_collection.update)
-	
-	undo_redo.commit_action()
-	enable()
-
+	assert("NOT_IMPLEMENTED")
 
 func remove_command(command:CommandClass) -> void:
-	if not _current_collection: return
-	if not command: return
-	var command_collection:CollectionClass
-	if not command.weak_owner:
-		push_error("not command.weak_owner")
-		return
-	command_collection = command.get_command_owner()
-	if not command_collection:
-		push_error("not command_collection")
-		return
-	
-	var action_name:String = "Remove command '%s'" % [command.command_name]
-	
-	disable()
-	undo_redo.create_action(action_name)
-		
-	undo_redo.add_do_method(command_collection.remove.bind(command.index))
-	undo_redo.add_undo_method(command_collection.insert.bind(command, command.index))
-	
-	undo_redo.add_do_method(_current_collection.update)
-	undo_redo.add_undo_method(_current_collection.update)
-	
-	undo_redo.commit_action()
-	enable()
+	assert("NOT_IMPLEMENTED")
 
 
 func copy_command(command:CommandClass) -> void:
@@ -405,6 +285,7 @@ func _displayer_display_finished() -> void:
 		return
 	
 	if is_instance_valid(last_selected_command.editor_block):
+		if last_selected_command.editor_block.is_queued_for_deletion(): return
 		last_selected_command.editor_block.select()
 
 

--- a/editor/views/editor_view.gd
+++ b/editor/views/editor_view.gd
@@ -1,6 +1,8 @@
 @tool
 extends PanelContainer
 
+signal command_selected(resource)
+
 const Constants = preload("res://addons/blockflow/editor/constants.gd")
 
 const CommandList = preload("res://addons/blockflow/editor/command_list.gd")
@@ -391,6 +393,7 @@ func _displayer_command_selected(command:CommandClass) -> void:
 	
 	_current_command = command
 	last_selected_command = command
+	command_selected.emit(last_selected_command)
 
 func _displayer_display_finished() -> void:
 	if not last_selected_command:
@@ -500,6 +503,7 @@ func _init() -> void:
 	size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	size_flags_vertical = Control.SIZE_EXPAND_FILL
 	theme = load(Constants.DEFAULT_THEME_PATH) as Theme
+	theme_type_variation = "BlockEditor"
 	
 	command_popup = PopupMenu.new()
 	command_popup.name = "ItemPopup"

--- a/editor/views/editor_view.gd
+++ b/editor/views/editor_view.gd
@@ -67,7 +67,6 @@ func edit(object:Object) -> void:
 	
 	if object is CommandClass:
 		edited_object = object
-		left_section_hide()
 		_edit_command()
 		return
 	

--- a/editor/views/editor_view.gd
+++ b/editor/views/editor_view.gd
@@ -22,7 +22,6 @@ enum ToolbarFileMenu {
 	RECENT,
 }
 
-static var editors := {}
 static var command_clipboard:CommandClass
 
 var edited_object:Object:
@@ -460,9 +459,6 @@ func _init() -> void:
 	section_right.add_child(command_list)
 	
 	command_record = CommandRecord.new().get_record()
-	
-	editors[&"unknow_editors"] = editors.get(&"unknow_editors", [])
-	editors[&"unknow_editors"].append(self)
 	
 	displayer = DisplayerFancy.new()
 	displayer.command_selected.connect(_displayer_command_selected)

--- a/editor/views/in_editor_view.gd
+++ b/editor/views/in_editor_view.gd
@@ -1,0 +1,135 @@
+@tool
+extends "res://addons/blockflow/editor/views/editor_view.gd"
+
+var editor_undo_redo:EditorUndoRedoManager
+
+func add_command(command:CommandClass, at_position:int = -1, to_collection:CollectionClass = null) -> void:
+	if not _current_collection: return
+	if not command: return
+	if not to_collection:
+		to_collection = _current_collection
+	
+	var action_name:String = "Add command '%s'" % [command.command_name]
+	last_selected_command = command
+	
+	disable()
+	editor_undo_redo.create_action(action_name, 0, edited_object)
+	
+	if at_position < 0:
+		editor_undo_redo.add_do_method(to_collection, &"add", command)
+	else:
+		editor_undo_redo.add_do_method(to_collection, &"insert", command, at_position)
+	
+	editor_undo_redo.add_undo_method(to_collection, &"erase", command)
+	
+	editor_undo_redo.add_do_method(_current_collection, &"update")
+	editor_undo_redo.add_undo_method(_current_collection, &"update")
+	
+	editor_undo_redo.commit_action()
+	enable()
+
+
+func move_command(command:CommandClass, to_position:int, from_collection:CollectionClass=null, to_collection:CollectionClass=null) -> void:
+	if not _current_collection: return
+	if not command: return
+	
+	if not from_collection:
+		from_collection = command.get_command_owner()
+	if not to_collection:
+		to_collection = command.get_command_owner()
+	
+	if not from_collection:
+		# It comes from nowhere, maybe we're adding instead of moving?
+		add_command(command, to_position, to_collection)
+		return
+
+	if to_collection == command:
+		push_error("Can't move into self!")
+		return
+
+	var weak_owner = to_collection.weak_owner
+	if weak_owner:
+		weak_owner = weak_owner.get_ref()
+	while weak_owner:
+		if weak_owner is WeakRef:
+			weak_owner = weak_owner.get_ref()
+		if weak_owner == command:
+			push_error("Found self in parents, can't move into self!")
+			return
+		weak_owner = weak_owner.weak_owner
+
+	var from_position:int = from_collection.get_command_position(command)
+	var action_name:String = "Move command '%s'" % [command.command_name]
+	
+	disable()
+	editor_undo_redo.create_action(action_name, 0, edited_object)
+	if from_collection == to_collection:
+		editor_undo_redo.add_do_method(from_collection, &"move", command, to_position)
+		editor_undo_redo.add_undo_method(from_collection, &"move", command, from_position)
+	else:
+		editor_undo_redo.add_do_method(from_collection, &"erase", command)
+		editor_undo_redo.add_undo_method(from_collection, &"insert", command, from_position)
+		editor_undo_redo.add_do_method(to_collection, &"insert", command, to_position)
+		editor_undo_redo.add_undo_method(to_collection, &"erase", command)
+	
+	editor_undo_redo.add_do_method(_current_collection, &"update")
+	editor_undo_redo.add_undo_method(_current_collection, &"update")
+	
+	editor_undo_redo.commit_action()
+	enable()
+
+func duplicate_command(command:CommandClass, to_index:int) -> void:
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("!command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("!command_collection")
+		return
+	
+	var action_name:String = "Duplicate command '%s'" % [command.command_name]
+	var duplicated_command = command.get_duplicated()
+	last_selected_command = duplicated_command
+	var idx = to_index if to_index > -1 else command_collection.size()
+	
+	disable()
+	editor_undo_redo.create_action(action_name, 0, edited_object)
+		
+	editor_undo_redo.add_do_method(command_collection, &"insert", duplicated_command, to_index)
+	editor_undo_redo.add_undo_method(command_collection, &"erase", duplicated_command)
+	
+	editor_undo_redo.add_do_method(_current_collection, &"update")
+	editor_undo_redo.add_undo_method(_current_collection, &"update")
+	
+	editor_undo_redo.commit_action()
+	enable()
+
+
+func remove_command(command:CommandClass) -> void:
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("not command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("not command_collection")
+		return
+	
+	var action_name:String = "Remove command '%s'" % [command.command_name]
+	
+	disable()
+	editor_undo_redo.create_action(action_name, 0, edited_object)
+	
+	editor_undo_redo.add_do_method(command_collection, &"remove", command.index)
+	editor_undo_redo.add_undo_method(command_collection, &"insert", command, command.index)
+	
+	editor_undo_redo.add_do_method(_current_collection, &"update")
+	editor_undo_redo.add_undo_method(_current_collection, &"update")
+	
+	editor_undo_redo.commit_action()
+	enable()

--- a/editor/views/in_runtime_editor_view.gd
+++ b/editor/views/in_runtime_editor_view.gd
@@ -1,0 +1,134 @@
+extends "res://addons/blockflow/editor/views/editor_view.gd"
+
+var undo_redo:UndoRedo
+
+func add_command(command:CommandClass, at_position:int = -1, to_collection:CollectionClass = null) -> void:
+	if not _current_collection: return
+	if not command: return
+	if not to_collection:
+		to_collection = _current_collection
+	
+	var action_name:String = "Add command '%s'" % [command.command_name]
+	last_selected_command = command
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	if at_position < 0:
+		undo_redo.add_do_method(to_collection.add.bind(command))
+	else:
+		undo_redo.add_do_method(to_collection.insert.bind(command, at_position))
+	
+	undo_redo.add_undo_method(to_collection.erase.bind(command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
+
+
+func move_command(command:CommandClass, to_position:int, from_collection:CollectionClass=null, to_collection:CollectionClass=null) -> void:
+	if not _current_collection: return
+	if not command: return
+	
+	if not from_collection:
+		from_collection = command.get_command_owner()
+	if not to_collection:
+		to_collection = command.get_command_owner()
+	
+	if not from_collection:
+		# It comes from nowhere, maybe we're adding instead of moving?
+		add_command(command, to_position, to_collection)
+		return
+
+	if to_collection == command:
+		push_error("Can't move into self!")
+		return
+
+	var weak_owner = to_collection.weak_owner
+	if weak_owner:
+		weak_owner = weak_owner.get_ref()
+	while weak_owner:
+		if weak_owner is WeakRef:
+			weak_owner = weak_owner.get_ref()
+		if weak_owner == command:
+			push_error("Found self in parents, can't move into self!")
+			return
+		weak_owner = weak_owner.weak_owner
+
+	var from_position:int = from_collection.get_command_position(command)
+	var action_name:String = "Move command '%s'" % [command.command_name]
+	
+	disable()
+	undo_redo.create_action(action_name)
+	if from_collection == to_collection:
+		undo_redo.add_do_method(from_collection.move.bind(command, to_position))
+		undo_redo.add_undo_method(from_collection.move.bind(command, from_position))
+	else:
+		undo_redo.add_do_method(from_collection.erase.bind(command))
+		undo_redo.add_undo_method(from_collection.insert.bind(command, from_position))
+		undo_redo.add_do_method(to_collection.insert.bind(command, to_position))
+		undo_redo.add_undo_method(to_collection.erase.bind(command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
+
+func duplicate_command(command:CommandClass, to_index:int) -> void:
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("!command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("!command_collection")
+		return
+	
+	var action_name:String = "Duplicate command '%s'" % [command.command_name]
+	var duplicated_command = command.get_duplicated()
+	last_selected_command = duplicated_command
+	var idx = to_index if to_index > -1 else command_collection.size()
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	undo_redo.add_do_method(command_collection.insert.bind(duplicated_command, to_index))
+	undo_redo.add_undo_method(command_collection.erase.bind(duplicated_command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
+
+
+func remove_command(command:CommandClass) -> void:
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("not command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("not command_collection")
+		return
+	
+	var action_name:String = "Remove command '%s'" % [command.command_name]
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	undo_redo.add_do_method(command_collection.remove.bind(command.index))
+	undo_redo.add_undo_method(command_collection.insert.bind(command, command.index))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/de8790ea-0d87-4f8e-a9b2-3de24372ceb8)

This is a kinda big update and I used this chance to adjust things for the future.

## What's new?

- I changed our Tree implementation with a custom/fake one, using a trick with a bunch of containers. It should fix https://github.com/AnidemDex/Blockflow/issues/92 . It also includes a multi-selection thing, so it should fix #106 (but it does nothing for now)
- I updated our `Command` to include stuff related to the new fake tree. It should fix https://github.com/AnidemDex/Blockflow/issues/164
- I also updated `Collection` to expose more internal properties, just for debug purposes, using a EditorInspector.

I think it also fix #161 and fix #107 (fix #92 for sure, fix #164)


Since now our command blocks are nodes and not objects (as was before with Tree), users can make their own blocks in custom scenes. I decided to **not** make the whole block replicate the old Tree look to force me to create a scene that mimics that old TreeItem look