### PR TITLE
Reimplement undoredo

### DIFF
--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -2,7 +2,7 @@
 extends EditorPlugin
 
 const Blockflow = preload("res://addons/blockflow/blockflow.gd")
-const BlockEditor = preload("res://addons/blockflow/editor/views/in_editor_view.gd")
+const BlockEditor = preload("res://addons/blockflow/editor/views/editor_view.gd")
 const InspectorTools = preload("res://addons/blockflow/editor/inspector/inspector_tools.gd")
 const CollectionInspector = preload("res://addons/blockflow/editor/inspector/collection_inspector.gd")
 const CommandInspector = preload("res://addons/blockflow/editor/inspector/command_inspector.gd")
@@ -153,7 +153,6 @@ func _block_editor_command_selected(command) -> void:
 
 func _init() -> void:
 	block_editor = BlockEditor.new()
-	block_editor.editor_undo_redo = get_undo_redo()
 	block_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	block_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	block_editor.command_selected.connect(_block_editor_command_selected)

--- a/editor/constants.gd
+++ b/editor/constants.gd
@@ -45,3 +45,5 @@ const SHORTCUT_DELETE = preload("res://addons/blockflow/editor/shortcuts/delete.
 const SHORTCUT_COPY = preload("res://addons/blockflow/editor/shortcuts/copy.tres")
 const SHORTCUT_PASTE = preload("res://addons/blockflow/editor/shortcuts/paste.tres")
 const SHORTCUT_OPEN_MENU = preload("res://addons/blockflow/editor/shortcuts/open_menu.tres")
+const SHORTCUT_UNDO = preload("res://addons/blockflow/editor/shortcuts/undo.tres")
+const SHORTCUT_REDO = preload("res://addons/blockflow/editor/shortcuts/redo.tres")

--- a/editor/shortcuts/redo.tres
+++ b/editor/shortcuts/redo.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Shortcut" load_steps=2 format=3 uid="uid://on3hil8pvm5"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_tdry3"]
+device = -1
+command_or_control_autoremap = true
+shift_pressed = true
+keycode = 90
+
+[resource]
+events = [SubResource("InputEventKey_tdry3")]

--- a/editor/shortcuts/undo.tres
+++ b/editor/shortcuts/undo.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Shortcut" load_steps=2 format=3 uid="uid://dvcy7wrd546sc"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_8bb5e"]
+device = -1
+command_or_control_autoremap = true
+keycode = 90
+
+[resource]
+events = [SubResource("InputEventKey_8bb5e")]

--- a/editor/views/editor_view.gd
+++ b/editor/views/editor_view.gd
@@ -27,6 +27,8 @@ static var command_clipboard:CommandClass
 var edited_object:Object:
 	set=edit
 
+var undo_redo:UndoRedo
+
 var history:Dictionary
 var last_selected_command:CommandClass
 var command_record:CommandRecord
@@ -63,6 +65,9 @@ var _current_command:CommandClass
 
 func edit(object:Object) -> void:
 	edited_object = null
+	if not undo_redo:
+		undo_redo = UndoRedo.new()
+		tree_exited.connect(undo_redo.free)
 	#if object is TimelineClass:
 		#left_section_show()
 		#_edit_timeline()
@@ -96,16 +101,133 @@ func close() -> void:
 	assert("NOT_IMPLEMENTED")
 
 func add_command(command:CommandClass, at_position:int = -1, to_collection:CollectionClass = null) -> void:
-	assert("NOT_IMPLEMENTED")
+	if not _current_collection: return
+	if not command: return
+	if not to_collection:
+		to_collection = _current_collection
+	
+	var action_name:String = "Add command '%s'" % [command.command_name]
+	last_selected_command = command
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	if at_position < 0:
+		undo_redo.add_do_method(to_collection.add.bind(command))
+	else:
+		undo_redo.add_do_method(to_collection.insert.bind(command, at_position))
+	
+	undo_redo.add_undo_method(to_collection.erase.bind(command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
 
 func move_command(command:CommandClass, to_position:int, from_collection:CollectionClass=null, to_collection:CollectionClass=null) -> void:
-	assert("NOT_IMPLEMENTED")
+	if not _current_collection: return
+	if not command: return
+	
+	if not from_collection:
+		from_collection = command.get_command_owner()
+	if not to_collection:
+		to_collection = command.get_command_owner()
+	
+	if not from_collection:
+		# It comes from nowhere, maybe we're adding instead of moving?
+		add_command(command, to_position, to_collection)
+		return
+
+	if to_collection == command:
+		push_error("Can't move into self!")
+		return
+
+	var weak_owner = to_collection.weak_owner
+	if weak_owner:
+		weak_owner = weak_owner.get_ref()
+	while weak_owner:
+		if weak_owner is WeakRef:
+			weak_owner = weak_owner.get_ref()
+		if weak_owner == command:
+			push_error("Found self in parents, can't move into self!")
+			return
+		weak_owner = weak_owner.weak_owner
+
+	var from_position:int = from_collection.get_command_position(command)
+	var action_name:String = "Move command '%s'" % [command.command_name]
+	
+	disable()
+	undo_redo.create_action(action_name)
+	if from_collection == to_collection:
+		undo_redo.add_do_method(from_collection.move.bind(command, to_position))
+		undo_redo.add_undo_method(from_collection.move.bind(command, from_position))
+	else:
+		undo_redo.add_do_method(from_collection.erase.bind(command))
+		undo_redo.add_undo_method(from_collection.insert.bind(command, from_position))
+		undo_redo.add_do_method(to_collection.insert.bind(command, to_position))
+		undo_redo.add_undo_method(to_collection.erase.bind(command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
 
 func duplicate_command(command:CommandClass, to_index:int) -> void:
-	assert("NOT_IMPLEMENTED")
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("!command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("!command_collection")
+		return
+	
+	var action_name:String = "Duplicate command '%s'" % [command.command_name]
+	var duplicated_command = command.get_duplicated()
+	last_selected_command = duplicated_command
+	var idx = to_index if to_index > -1 else command_collection.size()
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	undo_redo.add_do_method(command_collection.insert.bind(duplicated_command, to_index))
+	undo_redo.add_undo_method(command_collection.erase.bind(duplicated_command))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
 
 func remove_command(command:CommandClass) -> void:
-	assert("NOT_IMPLEMENTED")
+	if not _current_collection: return
+	if not command: return
+	var command_collection:CollectionClass
+	if not command.weak_owner:
+		push_error("not command.weak_owner")
+		return
+	command_collection = command.get_command_owner()
+	if not command_collection:
+		push_error("not command_collection")
+		return
+	
+	var action_name:String = "Remove command '%s'" % [command.command_name]
+	
+	disable()
+	undo_redo.create_action(action_name)
+		
+	undo_redo.add_do_method(command_collection.remove.bind(command.index))
+	undo_redo.add_undo_method(command_collection.insert.bind(command, command.index))
+	
+	undo_redo.add_do_method(_current_collection.update)
+	undo_redo.add_undo_method(_current_collection.update)
+	
+	undo_redo.commit_action()
+	enable()
 
 
 func copy_command(command:CommandClass) -> void:

--- a/editor/views/in_runtime_editor_view.gd
+++ b/editor/views/in_runtime_editor_view.gd
@@ -1,7 +1,5 @@
 extends "res://addons/blockflow/editor/views/editor_view.gd"
 
-var undo_redo:UndoRedo
-
 func add_command(command:CommandClass, at_position:int = -1, to_collection:CollectionClass = null) -> void:
 	if not _current_collection: return
 	if not command: return


### PR DESCRIPTION
Part of #179 fix, it discards EditorUndoRedo to use UndoRedo directly. This makes things simpler to manage but adds a layer of complexity since we must implement now our own UndoRedo manager for each resource.
---
Also adds a fancy editor button with undo/redo actions (and fixes the undo/redo shortcuts)

<img width="236" height="240" alt="image" src="https://github.com/user-attachments/assets/0e331f6c-c05a-400f-aae7-7996c1edabb0" />
