### PR TITLE
Fix a bug where the command list was not displayed at startup.

### DIFF
--- a/core/plugin_script.gd
+++ b/core/plugin_script.gd
@@ -177,7 +177,8 @@ func _init() -> void:
 	debugger = BlockflowDebugger.new()
 	
 	command_record = Blockflow.CommandRecord.new().get_record()
-	project_settings_changed.connect(command_record.reload_from_project_settings.bind(true))
+	ProjectSettings.settings_changed.connect(command_record.reload_from_project_settings.bind(true))
+	command_record.reload_from_project_settings(true)
 	
 	# Add the plugin to the list when we're created as soon as possible.
 	# Existing doesn't mean that plugin is ready, be careful with that.


### PR DESCRIPTION
The current code works in Godot 4.3, but in Godot 4.5 the command list is empty when the editor is launched.
`project_settings_changed` was deprecated in Godot 4.2.
And `ProjectSettings.settings_changed` is not emitted when the editor is launched.